### PR TITLE
Generate from cogex

### DIFF
--- a/go_networks/__main__.py
+++ b/go_networks/__main__.py
@@ -1,0 +1,6 @@
+"""Update the go_networks"""
+
+from go_networks.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -6,7 +6,8 @@ import click
 
 
 TEST_SET = "d7acdc1d-a08f-11ec-b3be-0ac135e8bacf"
-PROD_SET = "4c2006cd-9fef-11ec-b3be-0ac135e8bacf"
+STYLE_NX = "4c2006cd-9fef-11ec-b3be-0ac135e8bacf"
+PROD_SET = "303190ca-aac0-11ec-b3be-0ac135e8bacf"
 
 
 @click.group("go-networks")
@@ -33,8 +34,8 @@ def main():
     type=str,
     # See style network at
     # https://www.ndexbio.org/viewer/networks/4c2006cd-9fef-11ec-b3be-0ac135e8bacf
-    default="4c2006cd-9fef-11ec-b3be-0ac135e8bacf",
-    help="Network ID of the style network",
+    default=STYLE_NX,
+    help=f"Network ID of the style network. Default: {STYLE_NX}",
 )
 @click.option(
     "--local-sif",
@@ -79,13 +80,13 @@ def test(
 @click.option(
     "--style-network",
     type=str,
-    default=PROD_SET,
-    help="Network ID of the style network",
+    default=STYLE_NX,
+    help=f"Network ID of the style network. Default: {STYLE_NX}",
 )
 @click.option(
     "--network-set",
-    help="Network set ID to add the new networks to.",
-    default="bdba6a7a-488a-11ec-b3be-0ac135e8bacf",
+    help=f"Network set ID to add the new networks to. Default: {PROD_SET}",
+    default=PROD_SET,
 )
 @click.option(
     "--local-sif",

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -5,6 +5,10 @@ from generate_v2 import main as gen_networks
 import click
 
 
+TEST_SET = "d7acdc1d-a08f-11ec-b3be-0ac135e8bacf"
+PROD_SET = "4c2006cd-9fef-11ec-b3be-0ac135e8bacf"
+
+
 @click.group("go-networks")
 def main():
     """Update the go_networks"""
@@ -47,7 +51,7 @@ def test(
     # d7acdc1d-a08f-11ec-b3be-0ac135e8bacf
     gen_networks(
         local_sif=local_sif,
-        network_set="d7acdc1d-a08f-11ec-b3be-0ac135e8bacf",
+        network_set=TEST_SET,
         style_network=style_network,
         regenerate=regenerate_props,
         test_go_term=go_term,
@@ -64,7 +68,7 @@ def test(
 @click.option(
     "--style-network",
     type=str,
-    default="4c2006cd-9fef-11ec-b3be-0ac135e8bacf",
+    default=PROD_SET,
     help="Network ID of the style network",
 )
 @click.option(

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -1,0 +1,96 @@
+from typing import Optional
+
+from generate_v2 import main as gen_networks
+
+import click
+
+
+@click.group("go-networks")
+def main():
+    """Update the go_networks"""
+
+
+@main.command()
+@click.option(
+    "--regenerate-props",
+    is_flag=True,
+    help="Regenerate the properties file. Use this option if the underlying "
+    "data has changed. If there is no local props file cached, a new one "
+    "will be generated regardless of this flag.",
+)
+@click.option(
+    "--go-term",
+    type=str,
+    default="GO:2001239",
+    help="The GO term to generate the network for. Default: GO:2001239",
+)
+@click.option(
+    "--style-network",
+    type=str,
+    default="4c2006cd-9fef-11ec-b3be-0ac135e8bacf",
+    help="Network ID of the style network",
+)
+@click.option(
+    "--local-sif",
+    type=str,
+    required=True,
+    help="Path to a local SIF file.",
+)
+def test(
+    regenerate_props: bool,
+    go_term: str,
+    style_network: str,
+    local_sif: Optional[str] = None,
+):
+    """Build a test network."""
+    # Use the test network set:
+    # d7acdc1d-a08f-11ec-b3be-0ac135e8bacf
+    gen_networks(
+        local_sif=local_sif,
+        network_set="d7acdc1d-a08f-11ec-b3be-0ac135e8bacf",
+        style_network=style_network,
+        regenerate=regenerate_props,
+        test_go_term=go_term,
+    )
+
+
+@main.command()
+@click.option(
+    "--regenerate-props",
+    is_flag=True,
+    help="Regenerate the properties file. Use this option if the underlying "
+    "data has changed.",
+)
+@click.option(
+    "--style-network",
+    type=str,
+    default="4c2006cd-9fef-11ec-b3be-0ac135e8bacf",
+    help="Network ID of the style network",
+)
+@click.option(
+    "--network-set",
+    help="Network set ID to add the new networks to.",
+    default="bdba6a7a-488a-11ec-b3be-0ac135e8bacf",
+)
+@click.option(
+    "--local-sif",
+    type=str,
+    help="Path to a local SIF file to use instead of downloading from S3.",
+)
+def run(
+    regenerate_props: bool,
+    style_network: str,
+    network_set: str,
+    local_sif: Optional[str] = None,
+):
+    """Run the go network generation."""
+    gen_networks(
+        local_sif=local_sif,
+        network_set=network_set,
+        style_network=style_network,
+        regenerate=regenerate_props,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -31,6 +31,8 @@ def main():
 @click.option(
     "--style-network",
     type=str,
+    # See style network at
+    # https://www.ndexbio.org/viewer/networks/4c2006cd-9fef-11ec-b3be-0ac135e8bacf
     default="4c2006cd-9fef-11ec-b3be-0ac135e8bacf",
     help="Network ID of the style network",
 )

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -42,11 +42,19 @@ def main():
     help="Path to a local SIF file. Only needed if we are regenerating the "
     "properties file.",
 )
+@click.option(
+    "--ndex-server-style",
+    type=str,
+    default="http://ndexbio.org",
+    help="The URL of the ndex server to use for the style network. "
+    "Default: http://ndexbio.org",
+)
 def test(
     regenerate_props: bool,
     go_term: str,
     style_network: str,
     local_sif: Optional[str] = None,
+    ndex_server_style: str = "http://ndexbio.org",
 ):
     """Build a test network."""
     # Use the test network set:
@@ -57,6 +65,7 @@ def test(
         style_network=style_network,
         regenerate=regenerate_props,
         test_go_term=go_term,
+        ndex_server_style=ndex_server_style,
     )
 
 

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -7,7 +7,8 @@ import click
 
 TEST_SET = "d7acdc1d-a08f-11ec-b3be-0ac135e8bacf"
 STYLE_NX = "4c2006cd-9fef-11ec-b3be-0ac135e8bacf"
-PROD_SET = "303190ca-aac0-11ec-b3be-0ac135e8bacf"
+PROD_SET = "bdba6a7a-488a-11ec-b3be-0ac135e8bacf"
+SECONDARY_SET = "303190ca-aac0-11ec-b3be-0ac135e8bacf"
 
 
 @click.group("go-networks")

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -33,8 +33,8 @@ def main():
 @click.option(
     "--local-sif",
     type=str,
-    required=True,
-    help="Path to a local SIF file.",
+    help="Path to a local SIF file. Only needed if we are regenerating the "
+    "properties file.",
 )
 def test(
     regenerate_props: bool,

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -39,12 +39,6 @@ def main():
     help=f"Network ID of the style network. Default: {STYLE_NX}",
 )
 @click.option(
-    "--local-sif",
-    type=str,
-    help="Path to a local SIF file. Only needed if we are regenerating the "
-    "properties file.",
-)
-@click.option(
     "--ndex-server-style",
     type=str,
     default="http://ndexbio.org",
@@ -55,14 +49,12 @@ def test(
     regenerate_props: bool,
     go_term: str,
     style_network: str,
-    local_sif: Optional[str] = None,
     ndex_server_style: str = "http://ndexbio.org",
 ):
     """Build a test network."""
     # Use the test network set:
     # d7acdc1d-a08f-11ec-b3be-0ac135e8bacf
     gen_networks(
-        local_sif=local_sif,
         network_set=TEST_SET,
         style_network=style_network,
         regenerate=regenerate_props,
@@ -89,20 +81,13 @@ def test(
     help=f"Network set ID to add the new networks to. Default: {PROD_SET}",
     default=PROD_SET,
 )
-@click.option(
-    "--local-sif",
-    type=str,
-    help="Path to a local SIF file to use instead of downloading from S3.",
-)
 def run(
     regenerate_props: bool,
     style_network: str,
     network_set: str,
-    local_sif: Optional[str] = None,
 ):
     """Run the go network generation."""
     gen_networks(
-        local_sif=local_sif,
         network_set=network_set,
         style_network=style_network,
         regenerate=regenerate_props,

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from generate_v2 import main as gen_networks
+from go_networks.generate_v2 import main as gen_networks
 
 import click
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -7,7 +7,7 @@ import pickle
 import obonet
 from itertools import combinations
 from pathlib import Path
-from typing import Optional, Dict, Set, Tuple
+from typing import Optional, Dict, Set, Tuple, Union
 
 import ndex2.client
 from ndex2 import create_nice_cx_from_server, NiceCXNetwork
@@ -47,11 +47,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_curation_set() -> Set[int]:
-
     def _is_incorrect(stmt_hash, evid_hash):
         # Evidence is incorrect if it was only curated as incorrect
-        if evid_hash in correct_stmt_evid[stmt_hash]['incorrect'] and \
-                evid_hash not in correct_stmt_evid[stmt_hash]['correct']:
+        if (
+            evid_hash in correct_stmt_evid[stmt_hash]["incorrect"]
+            and evid_hash not in correct_stmt_evid[stmt_hash]["correct"]
+        ):
             return True
         return False
 
@@ -340,7 +341,7 @@ def genes_by_go_id():
 def build_networks(
     go2genes_map: Go2Genes,
     pair_props: PropDict,
-) -> Dict[str, GoNetworkAssembler]:
+) -> Dict[str, Dict[str, Union[NiceCXNetwork, float]]]:
     """Build networks per go-id associated genes
 
     Parameters
@@ -422,7 +423,7 @@ def generate(
     props_file: Optional[str] = None,
     apply_filters: bool = True,
     regenerate: bool = False,
-):
+) -> Dict[str, Dict[str, Union[NiceCXNetwork, float]]]:
     """Generate new GO networks from INDRA statements
 
     Parameters
@@ -541,9 +542,7 @@ def main(
             logger.info(f"Writing networks to {NETWORKS_FILE}")
             pickle.dump(networks, f)
 
-    style_ncx = create_nice_cx_from_server(
-        server=ndex_server_style, uuid=style_network
-    )
+    style_ncx = create_nice_cx_from_server(server=ndex_server_style, uuid=style_network)
 
     from indra.databases import ndex_client
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -298,7 +298,7 @@ def build_networks(
     # Only pass the relevant parts of the pair_props dict
     for go_id, gene_set in tqdm(go2genes_map.items(), total=len(go2genes_map)):
         # debug: skip all but one go-id
-        if go_id != 'GO:0046784':
+        if go_id != 'GO:2001239':
             continue
 
         def _key(g1, g2):

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -482,6 +482,31 @@ def format_and_upload_network(
     return network_id
 
 
+def _update_style_network(style_ncx: NiceCXNetwork, min_score: float, max_score: float):
+    if NiceCXNetwork.CY_VISUAL_PROPERTIES in style_ncx.opaqueAspects:
+        vis_prop = NiceCXNetwork.CY_VISUAL_PROPERTIES
+        for style_dict in style_ncx.opaqueAspects[vis_prop]:
+            if style_dict["properties_of"] == "edges:default":
+                style_str = style_dict["mappings"]["EDGE_WIDTH"]["definition"]
+                styles = style_str.split(",")
+                min_ix = -1
+                max_ix = -1
+                for st in styles:
+                    if "OV=0=" in st:
+                        min_ix = styles.index(st)
+                    if "OV=1=" in st:
+                        max_ix = styles.index(st)
+                    if min_ix != -1 and max_ix != -1:
+                        break
+                styles[min_ix] = f"OV=0={min_score}"
+                styles[max_ix] = f"OV=1={max_score}"
+                style_dict["mappings"]["EDGE_WIDTH"]["definition"] = ",".join(styles)
+                break
+
+        assert f"OV=0={min_score}" in style_dict["mappings"]["EDGE_WIDTH"]["definition"]
+        assert f"OV=1={max_score}" in style_dict["mappings"]["EDGE_WIDTH"]["definition"]
+
+
 def main(
     network_set: str,
     style_network: str,

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -408,7 +408,7 @@ if __name__ == "__main__":
             pickle.dump(networks, f)
 
     style_ncx = create_nice_cx_from_server(
-        server='http://test.ndexbio.org',
+        server='http://ndexbio.org',
         uuid=args.style_network)
 
     from indra.databases import ndex_client

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -22,6 +22,7 @@ from go_networks.util import (
     DIRECTED_TYPES,
     get_ndex_web_client,
     get_networks_in_set,
+    NDEX_ARGS,
 )
 from go_networks.network_assembly import GoNetworkAssembler
 
@@ -467,6 +468,44 @@ def generate(
 
     # Iterate by GO ID and for each list of genes, build a network
     return build_networks(go2genes_map, sif_props)
+
+
+def download_ncx_from_uuids(ncx_uuids):
+    # Download the set of NiceCXnetworks given by the UUIDS
+    res = {}
+    for ncx_uuid in tqdm(ncx_uuids, desc="Downloading NCX"):
+        ncx = create_nice_cx_from_server(uuid=ncx_uuid, **NDEX_ARGS)
+        res[ncx_uuid] = ncx
+
+    return res
+
+
+def get_ncx_cache_from_set(ncx_set_uuid: str):
+    ncx_cache = {}
+    ndex_web_client = get_ndex_web_client()
+    ncx_uuids = get_networks_in_set(ncx_set_uuid, client=ndex_web_client)
+    for ncx_uuid in tqdm(ncx_uuids,
+                         desc=f"Downloading NCX from set {ncx_set_uuid}"):
+        ncx = create_nice_cx_from_server(uuid=ncx_uuid, **NDEX_ARGS)
+
+        # network_info = ndex_web_client.get_network_summary(ncx_uuid)
+
+        # Get the go id
+        # go_id = None
+        # for prop_dict in network_info["properties"]:
+        #     if prop_dict["predicateString"] == "GO ID":
+        #         go_id = prop_dict["value"]
+        #         break
+        #     else:
+        #         continue
+        # if go_id is None:
+        #     logger.warning(f"No GO ID found for network {ncx_uuid}")
+        #     continue
+
+        # ncx_cache[go_id] = {"uuid": ncx_uuid, "ncx": ncx}
+        ncx_cache[ncx_uuid] = ncx
+
+    return ncx_cache
 
 
 def get_go_uuid_mapping(set_uuid: str) -> Dict[str, str]:

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -316,10 +316,21 @@ def go_term_gene_query() -> Iterator[Tuple[Node, Node]]:
     )
 
 
-def genes_by_go_id() -> Dict[str, Set[str]]:
-    """Map go ids to gene symbols."""
+def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
+    """Map go ids to gene symbols
+
+    Parameters
+    ----------
+    regenerate :
+        Whether to regenerate the cache. If True, the cache will be overwritten.
+
+    Returns
+    -------
+    :
+        A dictionary mapping go ids to sets of gene symbols
+    """
     # Get all go IDs from the database, unless they're cached
-    if GO_MAPPINGS.exists():
+    if GO_MAPPINGS.exists() and not regenerate:
         logger.info("Loading GO mapping from cache")
         with GO_MAPPINGS.open(mode="rb") as fr:
             return pickle.load(fr)
@@ -443,7 +454,7 @@ def generate(
         props file, if it exists.
     """
     # Make genes by GO ID dict
-    go2genes_map = genes_by_go_id()
+    go2genes_map = genes_by_go_id(regenerate=regenerate)
 
     # Filter GO IDs
     go2genes_map = filter_go_ids(go2genes_map)

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -387,7 +387,7 @@ if __name__ == "__main__":
                         default='bdba6a7a-488a-11ec-b3be-0ac135e8bacf')
     parser.add_argument('--style-network',
                         help='Network ID of the style network',
-                        default='8e503fda-7110-11e9-b14c-0660b7976219')
+                        default='4c2006cd-9fef-11ec-b3be-0ac135e8bacf')
     parser.add_argument('--regenerate', action='store_true',
                         help='Regenerate the networks and re-cache them')
     args = parser.parse_args()

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -24,7 +24,7 @@ from go_networks.util import (
     get_networks_in_set,
     NDEX_ARGS,
 )
-from go_networks.network_assembly import GoNetworkAssembler, _get_cx_layout
+from go_networks.network_assembly import GoNetworkAssembler, get_cx_layout
 
 
 # Derived types
@@ -565,7 +565,7 @@ def update_coordinates_for_network(
     ncx: NiceCXNetwork = create_nice_cx_from_server(uuid=ncx_uuid, **NDEX_ARGS)
 
     # Get the coordinates
-    node_layout_by_name = _get_cx_layout(network=ncx)
+    node_layout_by_name = get_cx_layout(network=ncx)
 
     # Update the coordinates in the network
     node_name_id = {(nd['n'], _id) for _id, nd in ncx.nodes.items()}

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -111,7 +111,7 @@ def get_curation_set() -> Set[int]:
     return hashes_out
 
 
-def get_sif_from_cogex() -> pd.DataFrame:
+def get_sif_from_cogex(limit: Optional[int] = None) -> pd.DataFrame:
     """Get the SIF from Cogex
 
     Conditions:
@@ -120,6 +120,11 @@ def get_sif_from_cogex() -> pd.DataFrame:
         - Skip relations where evidence_count == 1 AND source is a reader
         - Skip relations where stmt_type == 'Complex' AND sparser is the only
         source
+
+    Parameters
+    ----------
+    limit :
+        Limit the number of edges to return. Useful for testing or debugging.
 
     Returns
     -------
@@ -145,6 +150,8 @@ def get_sif_from_cogex() -> pd.DataFrame:
     RETURN gene1, gene2, r.belief, r.evidence_count, r.source_counts, r.stmt_hash, r.stmt_type
     """
     )
+    if limit is not None and isinstance(limit, int):
+        query += f"LIMIT {limit}"
     n4j_client = Neo4jClient()
     logger.info("Getting interaction data from Cogex")
     results = n4j_client.query_tx(query)

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -431,7 +431,9 @@ def filter_go_ids(go2genes_map) -> Dict[str, Set[str]]:
     }
 
 
-def generate(regenerate: bool = False) -> Dict[str, Dict[str, Union[NiceCXNetwork, float]]]:
+def generate(
+    regenerate: bool = False,
+) -> Dict[str, Dict[str, Union[NiceCXNetwork, float]]]:
     """Generate new GO networks from INDRA statements
 
     Parameters
@@ -510,7 +512,9 @@ def format_and_update_network(
     # If we have a UUID, update the network
     if cx_uuid:
         try:
-            ndex_client.update_cx_network(cx_stream=ncx.to_cx_stream(), network_id=cx_uuid)
+            ndex_client.update_cx_network(
+                cx_stream=ncx.to_cx_stream(), network_id=cx_uuid
+            )
         except Exception as e:
             logger.warning(f"Failed to update network {cx_uuid}: {e}")
             failed_update = True

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_curation_set() -> Set[int]:
-    correct_tags = {"correct", "hypothesis", "activity_amount"}
+    correct_tags = {"correct", "hypothesis", "act_vs_amt"}
     try:
         curations = get_curations()
         # curations == {'pa_hash': 123456, 'tag': '<grounding tag>'}

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -473,10 +473,14 @@ def get_go_uuid_mapping(set_uuid: str) -> Dict[str, str]:
     :
         A dict mapping GO IDs to UUIDs of networks
     """
+    logger.info(f"Getting GO IDs for {set_uuid}")
+
     # Loop the networks in the set and get the go id for each network
     ndex_web_client = get_ndex_web_client()
     uuid_set = get_networks_in_set(network_set_id=set_uuid, client=ndex_web_client)
     go_uuid_mapping = {}
+
+    logger.info("Getting GO ID-uuid mapping")
     for cx_uuid in tqdm(uuid_set):
         # Get the info for the network
         network_info = ndex_web_client.get_network_summary(cx_uuid)
@@ -603,6 +607,7 @@ def main(
 
     failed_to_set_public = []
     failed_to_update = []
+    logger.info("Uploading networks to NDEx")
     for go_id, network_dict in tqdm(sorted(networks.items(), key=lambda x: x[0])):
         network = network_dict["network"]
         min_score = network_dict["min_score"]

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -153,24 +153,19 @@ def get_sif_from_cogex() -> pd.DataFrame:
     for r in tqdm(results):
         gene1 = n4j_client.neo4j_to_node(r[0])
         gene2 = n4j_client.neo4j_to_node(r[1])
-        belief = r[2]
-        ev_count = r[3]
-        src_counts = r[4]
-        stmt_hash = r[5]
-        stmt_type = r[6]
         res_tuples.append(
             (
-                gene1.db_ns,
-                gene1.db_id,
-                gene1.data["name"],
-                gene2.db_ns,
-                gene2.db_id,
-                gene2.data["name"],
-                belief,
-                ev_count,
-                src_counts,
-                stmt_hash,
-                stmt_type,
+                gene1.db_ns,         # agA_ns
+                gene1.db_id,         # agA_id
+                gene1.data["name"],  # agA_name
+                gene2.db_ns,         # agB_ns
+                gene2.db_id,         # agB_id
+                gene2.data["name"],  # agB_name
+                r[2],                # belief
+                r[3],                # evidence_count
+                r[4],                # source_counts
+                r[5],                # stmt_hash
+                r[6],                # stmt_type
             )
         )
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -381,6 +381,10 @@ def format_and_upload_network(
     ncx: NiceCXNetwork, network_set_id: str, style_ncx: NiceCXNetwork, **ndex_args
 ):
     """Take a NiceCXNetwork and upload it to NDEx."""
+    # Fixme: NiceCXNetwork.apply_style_from_network() does not exist in
+    #  ndex2==2.0.1 but ==2.0.1 is the requirement for INDRA
+    #  This method was added in 3.1.0:
+    #  https://github.com/ndexbio/ndex2-client/issues/43
     ncx.apply_style_from_network(style_ncx)
     network_url = ncx.upload_to(**ndex_args)
     network_id = network_url.split("/")[-1]

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -721,6 +721,21 @@ def get_networks_before_date_for_user(
     return res
 
 
+def delete_networks(network_uuids: Set[str], ndex_client: ndex2.Ndex2):
+    """Delete the networks provided by the UUIDs, return those that failed"""
+    failed = set()
+    for uuid in tqdm(network_uuids, desc="Deleting networks"):
+        try:
+            ndex_client.delete_network(uuid)
+        except Exception:
+            failed.add(uuid)
+
+    if failed:
+        logger.warning(f"{len(failed)} deletions failed")
+
+    return failed
+
+
 def format_and_update_network(
     ncx: NiceCXNetwork,
     network_set_id: str,

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -513,7 +513,7 @@ def format_and_update_network(
     # If we have a UUID, update the network
     if cx_uuid:
         try:
-            ndex_client.update_cx_network(cx_stream=ncx, network_id=cx_uuid)
+            ndex_client.update_cx_network(cx_stream=ncx.to_cx_stream(), network_id=cx_uuid)
         except Exception as e:
             logger.warning(f"Failed to update network {cx_uuid}: {e}")
             failed_update = True

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -37,6 +37,7 @@ GO_ANNOTS_PATH = HERE.joinpath("goa_human.gaf").absolute().as_posix()
 GO_OBO_PATH = HERE.joinpath("go.obo").absolute().as_posix()
 PROPS_FILE = HERE.joinpath("props.pkl").absolute().as_posix()
 NETWORKS_FILE = HERE.joinpath("networks.pkl").absolute().as_posix()
+DEFAULT_NDEX_SERVER = "http://ndexbio.org"
 TEST_GO_ID = None
 
 min_gene_count = 5
@@ -487,6 +488,7 @@ def main(
     regenerate: bool,
     local_sif: Optional[str] = None,
     test_go_term: Optional[str] = None,
+    ndex_server_style: str = DEFAULT_NDEX_SERVER,
 ):
     global TEST_GO_ID
     logger.info(f"Using network set id {network_set}")
@@ -494,6 +496,8 @@ def main(
     if test_go_term:
         logger.info(f"Testing GO term {test_go_term}")
         TEST_GO_ID = test_go_term
+
+    logger.info(f"Using ndex server {ndex_server_style} for style")
 
     networks = generate(
         sif_file=local_sif,
@@ -509,7 +513,7 @@ def main(
             pickle.dump(networks, f)
 
     style_ncx = create_nice_cx_from_server(
-        server="http://ndexbio.org", uuid=style_network
+        server=ndex_server_style, uuid=style_network
     )
 
     from indra.databases import ndex_client

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -613,6 +613,8 @@ def main(
 
         # Get uuid for GO term
         go_uuid = go_uuid_mapping.get(go_id)
+
+        # Update/upload network
         network_id, failed = format_and_update_network(
             ncx=network,
             network_set_id=network_set,
@@ -638,3 +640,6 @@ def main(
                 ndex_web_client.make_network_public(network_id=failed_uuid)
             except Exception as e:
                 logger.warning(f"Failed to set network {failed_uuid} public again: {e}")
+
+    if failed_to_update:
+        logger.warning(f"Failed to update {len(failed_to_update)} networks")

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -19,13 +19,11 @@ from tqdm import tqdm
 
 from go_networks.util import (
     DIRECTED_TYPES,
-    load_latest_sif,
+    get_ndex_web_client,
     get_networks_in_set,
 )
 from go_networks.network_assembly import GoNetworkAssembler
-from go_networks.util import DIRECTED_TYPES
 
-from go_networks.util import get_ndex_web_client
 
 # Derived types
 Term = Tuple[str, str]

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -6,7 +6,7 @@ import pickle
 from collections import defaultdict
 from itertools import combinations
 from textwrap import dedent
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterator, Optional, Set, Tuple, Union
 
 import ndex2.client
 import pandas as pd
@@ -600,7 +600,7 @@ def main(
 
     # Only cache the networks if we're not testing
     if not test_go_term:
-        with open(GO_NETWORKS, "wb") as f:
+        with GO_NETWORKS.open("wb") as f:
             logger.info(f"Writing networks to {GO_NETWORKS}")
             pickle.dump(networks, f)
     else:

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -297,6 +297,9 @@ def build_networks(
     skipped = 0
     # Only pass the relevant parts of the pair_props dict
     for go_id, gene_set in tqdm(go2genes_map.items(), total=len(go2genes_map)):
+        # debug: skip all but one go-id
+        if go_id != 'GO:0046784':
+            continue
 
         def _key(g1, g2):
             return tuple(sorted([g1, g2]))

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -612,7 +612,6 @@ def main(
     network_set: str,
     style_network: str,
     regenerate: bool,
-    local_sif: Optional[str] = None,
     test_go_term: Optional[str] = None,
     ndex_server_style: str = DEFAULT_NDEX_SERVER,
 ):

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -578,6 +578,8 @@ def main(
 
     if failed_to_set_public:
         logger.warning(f"Failed to set {len(failed_to_set_public)} networks public")
+        logger.info("Retrying to set networks public...")
+
         # Retry to set public
         for failed_uuid in failed_to_set_public:
             try:

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -662,7 +662,7 @@ def main(
 
     failed_to_set_public = []
     failed_to_update = []
-    logger.info("Uploading networks to NDEx")
+    logger.info(f"Uploading {len(networks)} networks to NDEx")
     for go_id, network_dict in tqdm(sorted(networks.items(), key=lambda x: x[0])):
         network = network_dict["network"]
         min_score = network_dict["min_score"]

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -163,7 +163,7 @@ def quality_filter(sif_df: pd.DataFrame) -> pd.DataFrame:
     ]
     t.update()
 
-    # Remove all rows where the source is sparser and the stmt type is Complex
+    # Remove all rows where sparser is the only source and the stmt type is Complex
     sif_df = sif_df[
         ~(
             (sif_df.stmt_type == "Complex")
@@ -350,7 +350,7 @@ def build_networks(
     Parameters
     ----------
     go2genes_map :
-        A dict mapping GO IDs to lists of genes
+        A dict mapping GO ID to a list of genes
     pair_props :
         Lookup for edges
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -135,7 +135,7 @@ def quality_filter(sif_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def generate_props(
-    sif_file: str,
+    sif_file: Optional[str] = None,
     props_file: Optional[str] = None,
     apply_filters: bool = True,
     regenerate: bool = False,
@@ -400,7 +400,10 @@ def generate(
 
     # Generate properties
     sif_props = generate_props(
-        sif_file, props_file, apply_filters=apply_filters, regenerate=regenerate
+        sif_file=sif_file,
+        props_file=props_file,
+        apply_filters=apply_filters,
+        regenerate=regenerate,
     )
 
     # Iterate by GO ID and for each list of genes, build a network
@@ -438,10 +441,10 @@ def format_and_upload_network(
 
 
 def main(
-    local_sif: str,
     network_set: str,
     style_network: str,
     regenerate: bool,
+    local_sif: Optional[str] = None,
     test_go_term: Optional[str] = None,
 ):
     global TEST_GO_ID
@@ -452,7 +455,10 @@ def main(
         TEST_GO_ID = test_go_term
 
     networks = generate(
-        local_sif, PROPS_FILE, apply_filters=True, regenerate=regenerate
+        sif_file=local_sif,
+        props_file=PROPS_FILE,
+        apply_filters=True,
+        regenerate=regenerate,
     )
 
     # Only cache the networks if we're not testing

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -35,7 +35,7 @@ EvCountDict = Dict[str, Dict[str, int]]
 NameEntityMap = Dict[str, Tuple[str, str]]
 
 # Constants
-HERE = Path(__file__).absolute().parent.parent
+HERE = Path(__file__).absolute().parent.parent.absolute().joinpath("old_networks")
 GO_ANNOTS_PATH = HERE.joinpath("goa_human.gaf").absolute().as_posix()
 GO_OBO_PATH = HERE.joinpath("go.obo").absolute().as_posix()
 PROPS_FILE = HERE.joinpath("props.pkl").absolute().as_posix()

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -622,6 +622,31 @@ def update_coordinates_for_network(
                                   network_id=ncx_uuid)
 
 
+def add_to_new_set(add_from_set_uuid: str,
+                   new_set_uuid: str,
+                   ndex_client: Optional[ndex2.Ndex2] = None):
+    """Add networks from one set to another"""
+    # Get client if not provided
+    t = tqdm(desc="Adding networks to new set", total=3)
+    ndex_client = get_ndex_web_client() if ndex_client is None else ndex_client
+    t.update()
+
+    # Get the networks in the input set
+    network_uuids = get_networks_in_set(network_set_id=add_from_set_uuid,
+                                        client=ndex_client)
+    t.update()
+
+    # Add the networks to the new set
+    # NOTE: the docstring typing in 'add_networks_to_networkset' says it
+    # returns None but a quick look at the code shows that it returns
+    # res.text or res.json() from a 'requests' response
+    res = ndex_client.add_networks_to_networkset(set_id=new_set_uuid,
+                                                 networks=network_uuids)
+    t.update()
+    t.close()
+    return res
+
+
 def format_and_update_network(
     ncx: NiceCXNetwork,
     network_set_id: str,

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -383,7 +383,11 @@ def build_networks(
             pair_properties=prop_dict,
         )
         gna.assemble()
-        networks[go_id] = gna.network
+        networks[go_id] = {
+            "network": gna.network,
+            "max_score": max(gna.rel_scores),
+            "min_score": min(gna.rel_scores),
+        }
 
     logger.info(f"Skipped {skipped} networks without statements")
     return networks
@@ -549,7 +553,14 @@ def main(
         "username": username,
         "password": password,
     }
-    for go_id, network in tqdm(sorted(networks.items(), key=lambda x: x[0])):
+    for go_id, network_dict in tqdm(sorted(networks.items(), key=lambda x: x[0])):
+        network = network_dict["network"]
+        min_score = network_dict["min_score"]
+        max_score = network_dict["max_score"]
+
+        # Update style network
+        _update_style_network(style_ncx, min_score=min_score, max_score=max_score)
+
         network_id = format_and_upload_network(
             network, network_set, style_ncx, **ndex_args
         )

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -262,11 +262,16 @@ class GoNetworkAssembler:
                 "https://db.indra.bio/statements/from_agents?"
                 f"{agent_query}&format=html&expand_all=true"
             )
+            # Edge attribute value should be:
+            # View All Evidence (123)
+            #   - Statement 1
+            #   - Statement 2
+            # etc.
             self.network.add_edge_attribute(
                 edge_id,
-                f"All statements involving {source} and {target}",
-                f'<a href="{url}" target="_blank">View all statements</a> '
-                f"involving {source} and {target}",
+                f"Relationship",
+                f'<a href="{url}" target="_blank">View all evidence '
+                f"({total_ev_count})</a> {html_list}",
                 "string",
             )
 

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -171,9 +171,13 @@ def _untangle_layout(g: nx.Graph, pos: NodeCoords):
                       x_mm=(x_min, x_max), y_mm=(y_min, y_max))
 
 
-def _get_cx_layout(
+def get_cx_layout(
     network: NiceCXNetwork, scale_factor: float = 500, untangle: bool = True
 ) -> Dict:
+    """Get a NiceCXNetwork compatible set of coordinates for the nodes
+
+    Returns a dict of coordinates keyed by the node
+    """
     # Convert to networkx graph
     g = network.to_networkx()
 

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -270,7 +270,7 @@ class GoNetworkAssembler:
             self.network.add_edge_attribute(
                 edge_id,
                 f"Relationship",
-                f'<a href="{url}" target="_blank">View all evidence '
+                f'<a href="{url}" target="_blank">View all evidences '
                 f"({total_ev_count})</a> {html_list}",
                 "string",
             )

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -355,7 +355,7 @@ class GoNetworkAssembler:
             )
 
         # Get layout by name now that the network is built
-        node_layout_by_name = _get_cx_layout(self.network)
+        node_layout_by_name = get_cx_layout(self.network)
 
         # Loop the entities again to add coordinates for each node
         layout_aspect = []

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -230,7 +230,7 @@ class GoNetworkAssembler:
             )
             # Add __relationship_score as attribute == ln(1+total_ev_count)
             self.network.add_edge_attribute(
-                edge_id, "__relationship_score", log(1 + total_ev_count), "double"
+                edge_id, "__relationship_score", 0.3 + log(total_ev_count), "double"
             )
 
             all_statements = []

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -1,3 +1,7 @@
+"""
+This file contains the GoNetworkAssembler class, which is used to assemble
+an Ndex network from a set of statements related to a given GO term.
+"""
 import json
 import logging
 from typing import List, Dict

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -228,9 +228,9 @@ class GoNetworkAssembler:
             total_ev_count = sum(
                 sum(d.values()) for d in (forward, reverse, undirected)
             )
-            # Add __relationship_score as attribute == ln(total_ev_count)
+            # Add __relationship_score as attribute == 1+ln(total_ev_count)
             self.network.add_edge_attribute(
-                edge_id, "__relationship_score", log(total_ev_count), "double"
+                edge_id, "__relationship_score", 1 + log(total_ev_count), "double"
             )
 
             all_statements = []

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -119,18 +119,18 @@ def _move_nodes_apart(
     distances = {(n1, n2): dist(pos[n1], pos[n2]) for n1, n2 in node_pairs}
 
     # Loop the pairs and update the position if it's too close
+    radius = 2*min_dist
     for n1, n2 in node_pairs:
         if distances[(n1, n2)] < min_dist:
             # Move n1 to a random position a radius == min_dist away from n2
-            xy1_new = _get_position_on_circle(pos[n2], min_dist)
-            new_min = min_dist
+            xy1_new = _get_position_on_circle(pos[n2], radius)
 
             # While the new position is still within the min-max of all
             # coordinates and there still is overlap, try a new distance and
             # angle
-            while _is_within(xy1_new) and _is_too_close(xy1_new, pos, new_min):
-                new_min += 0.5*min_dist
-                xy1_new = _get_position_on_circle(pos[n2], new_min)
+            while _is_within(xy1_new) and _is_too_close(xy1_new, pos, radius):
+                radius += 0.5*min_dist
+                xy1_new = _get_position_on_circle(pos[n2], radius)
 
             # Replace the current position of n1
             pos[n1] = list(xy1_new)

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Tuple
 
 import networkx as nx
 from networkx.drawing import layout
+from numpy import log
 
 from ndex2 import NiceCXNetwork
 
@@ -227,6 +228,11 @@ class GoNetworkAssembler:
             total_ev_count = sum(
                 sum(d.values()) for d in (forward, reverse, undirected)
             )
+            # Add __relationship_score as attribute == ln(total_ev_count)
+            self.network.add_edge_attribute(
+                edge_id, "__relationship_score", log(total_ev_count), "double"
+            )
+
             all_statements = []
             if forward:
                 all_statements.extend(

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -228,6 +228,10 @@ class GoNetworkAssembler:
             total_ev_count = sum(
                 sum(d.values()) for d in (forward, reverse, undirected)
             )
+            # Add __evidence_count
+            self.network.add_edge_attribute(
+                edge_id, "__evidence_count", total_ev_count, "integer"
+            )
             # Add __relationship_score as attribute == ln(1+total_ev_count)
             self.network.add_edge_attribute(
                 edge_id, "__relationship_score", 0.3 + log(total_ev_count), "double"

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -221,7 +221,7 @@ class GoNetworkAssembler:
                 edge_id, "__directed", True if forward else False, "boolean"
             )
             self.network.add_edge_attribute(
-                edge_id, "__reverse directed", True if reverse else False, "boolean"
+                edge_id, "__reverse_directed", True if reverse else False, "boolean"
             )
             # Get lists of english assembled statements with linkouts
             total_ev_count = sum(

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -147,10 +147,10 @@ class GoNetworkAssembler:
             "networkType": "pathway",
             "GO ID": identifier,
             "GO hierarchy": "biological process",
+            "GO term": self.go_name,
             "Prov:wasGeneratedBy": "INDRA",
             "Organism": "Homo sapiens (Human)",
-            "Description": self.go_name,
-            "Methods": "This network was assembled automatically by INDRA "
+            "Description": "This network was assembled automatically by INDRA "
             "(http://indra.bio) by processing all available biomedical "
             "literature with multiple machine reading systems, and "
             "integrating curated pathway databases. The network represents "

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -159,8 +159,8 @@ class GoNetworkAssembler:
             "GO hierarchy": "biological process",
             "GO term": self.go_name,
             "Prov:wasGeneratedBy": "INDRA",
-            "Organism": "Homo sapiens (Human)",
-            "Description": "This network was assembled automatically by INDRA "
+            "organism": "Human, 9606, H.sapiens",
+            "description": "This network was assembled automatically by INDRA "
             "(http://indra.bio) by processing all available biomedical "
             "literature with multiple machine reading systems, and "
             "integrating curated pathway databases. The network represents "

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -228,9 +228,9 @@ class GoNetworkAssembler:
             total_ev_count = sum(
                 sum(d.values()) for d in (forward, reverse, undirected)
             )
-            # Add __relationship_score as attribute == 1+ln(total_ev_count)
+            # Add __relationship_score as attribute == ln(1+total_ev_count)
             self.network.add_edge_attribute(
-                edge_id, "__relationship_score", 1 + log(total_ev_count), "double"
+                edge_id, "__relationship_score", log(1 + total_ev_count), "double"
             )
 
             all_statements = []

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -206,10 +206,10 @@ class GoNetworkAssembler:
             edge_id = self.network.create_edge(node_keys[source],
                                                node_keys[target],
                                                interaction_symbol)
-            self.network.add_edge_attribute(edge_id, 'directed',
+            self.network.add_edge_attribute(edge_id, '__directed',
                                             True if forward else False,
                                             'boolean')
-            self.network.add_edge_attribute(edge_id, 'reverse directed',
+            self.network.add_edge_attribute(edge_id, '__reverse directed',
                                             True if reverse else False,
                                             'boolean')
             if forward:

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -53,9 +53,7 @@ def _get_english_from_stmt_type(stmt_type: str, source: str, target: str) -> str
     return EnglishAssembler([stmt]).make_model()
 
 
-def edge_attribute_from_ev_counts(
-    source, target, ev_counts, directed
-) -> List[Tuple[str, int]]:
+def edge_attribute_from_ev_counts(source, target, ev_counts, directed) -> List[str]:
     parts = []
     for stmt_type, cnt in sorted(ev_counts.items(), key=lambda x: x[1], reverse=True):
         english = _get_english_from_stmt_type(stmt_type, source, target)
@@ -74,7 +72,7 @@ def edge_attribute_from_ev_counts(
                 f"agent0={source}&agent1={target}&type="
                 f"{stmt_type}&format=html&expand_all=true"
             )
-        part = (f'{english} (<a href="{url}" target="_blank">{cnt}</a>)', cnt)
+        part = f'{english} (<a href="{url}" target="_blank">{cnt}</a>)'
         parts.append(part)
     return parts
 
@@ -242,6 +240,12 @@ class GoNetworkAssembler:
                 all_statements.extend(
                     edge_attribute_from_ev_counts(source, target, undirected, False)
                 )
+
+            # Format the statements to an unordered list:
+            html_list = "<ul>"
+            for english in all_statements:
+                html_list += f"<li>{english}</li>"
+            html_list += "</ul>"
 
             # Add a linkout to all statements involving the pair
             if forward and reverse:

--- a/go_networks/network_assembly.py
+++ b/go_networks/network_assembly.py
@@ -4,7 +4,7 @@ an Ndex network from a set of statements related to a given GO term.
 """
 import json
 import logging
-from typing import List, Dict, Tuple
+from typing import List, Dict
 
 import networkx as nx
 from networkx.drawing import layout
@@ -165,6 +165,7 @@ class GoNetworkAssembler:
             "mechanistic interactions between genes/proteins that are "
             "associated with this GO process.",
         }
+        self.rel_scores = []
 
     def assemble(self):
         """Assemble cx network
@@ -233,8 +234,10 @@ class GoNetworkAssembler:
                 edge_id, "__evidence_count", total_ev_count, "integer"
             )
             # Add __relationship_score as attribute == ln(1+total_ev_count)
+            rel_score = 0.3 + log(total_ev_count)
+            self.rel_scores.append(rel_score)
             self.network.add_edge_attribute(
-                edge_id, "__relationship_score", 0.3 + log(total_ev_count), "double"
+                edge_id, "__relationship_score", rel_score, "double"
             )
 
             all_statements = []

--- a/go_networks/util.py
+++ b/go_networks/util.py
@@ -1,5 +1,4 @@
 import logging
-import pickle
 from pathlib import Path
 from typing import List, Dict, Optional
 
@@ -9,10 +8,8 @@ from ndex2 import Ndex2
 
 from indra.databases import ndex_client
 from indra.statements import *
-from indra_db.cli.dump import Sif, S3Path, get_latest_dump_s3_path
 
 __all__ = [
-    "load_latest_sif",
     "stmts_by_directedness",
     "DIRECTED_TYPES",
     "UNDIRECTED_TYPES",
@@ -25,18 +22,6 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 HERE = Path(__file__).absolute().parent
-
-
-def load_latest_sif() -> pd.DataFrame:
-    sif_s3p: S3Path = get_latest_dump_s3_path(Sif.name)
-    if sif_s3p is None:
-        raise ValueError("No sif file found on S3")
-
-    s3 = boto3.client("s3")
-    fileio = sif_s3p.get(s3)
-    sif_df = pickle.loads(fileio["Body"].read())
-    assert isinstance(sif_df, pd.DataFrame)
-    return sif_df
 
 
 def stmts_by_directedness(directed: bool) -> List[str]:
@@ -101,205 +86,3 @@ def get_networks_in_set(network_set_id: str, client: Optional[Ndex2]) -> List[st
         client = get_ndex_web_client()
     network_set = client.get_networkset(network_set_id)
     return network_set["networks"]
-
-
-# def set_directed(sif_df: pd.DataFrame):
-#     """Extend dataframe with column "directed" indicting directedness
-
-#     "directed": true if directed A->B statement exists otherwise false
-
-#     Parameters
-#     ----------
-#     sif_df:
-#         The dataframe to manipulate
-#     """
-
-#     # Extend with "directed" column: check rows that have directed stmt types
-#     directed_rows: pd.Series = sif_df.stmt_type.isin(DIRECTED_TYPES)
-#     undirected_rows: pd.Series = sif_df.stmt_type.isin(UNDIRECTED_TYPES)
-#     assert directed_rows.sum() + undirected_rows.sum() == sif_df.shape[0]
-
-#     # Set new column
-#     sif_df["directed"] = pd.NA
-
-#     # Set directed
-#     sif_df.loc[directed_rows, "directed"] = True
-
-#     # Set undirected
-#     sif_df.loc[undirected_rows, "directed"] = False
-
-#     # Check that no rows were left unset
-#     assert sif_df.directed.isna().sum() == 0
-
-
-# def set_reverse_directed(sif_df: pd.DataFrame):
-#     """Set reverse directed property for each pair (A, B)
-
-#     "reverse directed": true if directed B->A statement exists otherwise false
-
-#     Since each new value per row depends on looking up other rows, it's hard
-#     to implement some vectorized version, use temporary columns instead.
-
-#     Parameters
-#     ----------
-#     sif_df:
-#         DataFrame to set column reverse_directed in
-#     """
-#     # Set directed column if it doesn't exist
-#     if "directed" not in sif_df.columns:
-#         set_directed(sif_df)
-
-#     sif_df["reverse_directed"] = False
-
-#     # Set temporary column AB f'{agA_name}_{agB_name}'
-#     sif_df["AB"] = sif_df.agA_name + "_" + sif_df.agB_name
-#     # Set temporary column BA f'{agB_name}_{agA_name}'
-#     sif_df["BA"] = sif_df.agB_name + "_" + sif_df.agA_name
-
-#     # Set column reverse_directed:
-#     # "if each AB in BA & is directed"
-#     sif_df.loc[
-#         (sif_df.AB.isin(sif_df.BA.values) & sif_df.directed), "reverse_directed"
-#     ] = True
-#     assert (~sif_df.directed & sif_df.reverse_directed).sum() == 0
-
-#     # Drop temporary columns
-#     sif_df.drop(columns=["AB", "BA"], inplace=True)
-
-
-# def set_pair(sif_df: pd.DataFrame):
-#     """Set pair column in DataFrame
-
-#     The pair is constructed for each ordered pair (A, B) such that all
-#     interactions, directed or undirected, can be grouped together
-
-#     Parameters
-#     ----------
-#     sif_df :
-#         DataFrame to set column pair in
-#     """
-#     def pair(r):
-#         return '|'.join(sorted([r.agA_name, r.agB_name]))
-#     sif_df["pair"] = sif_df.apply(pair, axis=1)
-
-
-# STMTS_PKL: str = HERE.joinpath("_stmts_cache.pkl").absolute().as_posix()
-# STMT_CACHE: Dict[int, Statement] = {}
-
-# def download_statements(hashes: Set[int]) -> Dict[int, Statement]:
-#     """Get statements from a set of hashes
-
-#     Parameters
-#     ----------
-#     hashes :
-#         The set of hashes for the statements to download
-
-#     Returns
-#     -------
-#     :
-#         A dictionary mapping hash to statement
-#     """
-#     stmts_by_hash = {}
-#     logger.info(f"Downloading {len(hashes)} statements")
-#     for hash_iter in tqdm(
-#         batch_iter(hashes, batch_size=1000), total=len(hashes) // 1000 + 1
-#     ):
-#         idbp: DBQueryStatementProcessor = indra_db_rest.get_statements_by_hash(
-#             list(hash_iter), ev_limit=10
-#         )
-#         for stmt in idbp.statements:
-#             stmts_by_hash[stmt.get_hash()] = stmt
-#     return stmts_by_hash
-
-
-# def expand_complex(complex_stmt: Complex) -> List[Complex]:
-#     """Replace a Complex statement with a list of binary Complex statements
-
-#     Parameters
-#     ----------
-#     complex_stmt :
-#         A Complex statement to expand out to a list of statements
-
-#     Returns
-#     -------
-#     :
-#         A list of complexes with only two memebers
-#     """
-#     stmts = []
-#     added = set()
-#     for m1, m2 in combinations(complex_stmt.members, 2):
-#         keys = (m1.entity_matches_key(), m2.entity_matches_key())
-#         if keys in added:
-#             continue
-#         if len(set(keys)) == 1:
-#             continue
-#         ordered = sorted([m1, m2], key=lambda x: x.entity_matches_key())
-#         c = Complex(ordered, evidence=deepcopy(complex_stmt.evidence))
-#         stmts.append(c)
-#         added.add(keys)
-#     return stmts
-
-
-# def get_stmts(sif_df: pd.DataFrame) -> Dict[str, StmtsByDirectness]:
-#     # Get hashes by pair
-#     hashes_by_pair: Dict[str, List[int]] = list(
-#         sif_df.groupby("pair")
-#         .aggregate({"stmt_hash": lambda x: x.tolist()})
-#         .to_dict()
-#         .values()
-#     )[0]
-
-#     hashes = set(sif_df.stmt_hash)
-
-#     # Load cached statements
-#     if Path(STMTS_PKL).is_file():
-#         logger.info("Loading pickled statements")
-#         with Path(STMTS_PKL).open('rb') as f:
-#             pkl_stmts: Dict[int, Statement] = pickle.load(f)
-#         STMT_CACHE.update(pkl_stmts)
-#     else:
-#         pkl_stmts = {}
-
-#     # Get current stmts - check loaded stmts, then local cache
-#     stmt_by_hash = {h: st for h, st in pkl_stmts.items() if h in hashes}
-#     for h in hashes:
-#         if h in STMT_CACHE and h not in stmt_by_hash:
-#             stmt_by_hash[h] = STMT_CACHE[h]
-
-#     # stmt_by_hash.update({h: st for h, st in STMT_CACHE.items() if h in hashes})
-#     missing_hashes = hashes.difference(set(stmt_by_hash))
-
-#     if missing_hashes:
-#         # Download missing statements
-#         logger.info(f"Downloading {len(missing_hashes)} missing statements")
-#         new_stmts_by_hash = download_statements(missing_hashes)
-
-#         # Merge dicts
-#         stmt_by_hash.update(new_stmts_by_hash)
-
-#         # Update global
-#         STMT_CACHE.update(stmt_by_hash)
-
-#         # Check if new statements were added overall and write to cache
-#         if set(STMT_CACHE.keys()).difference(pkl_stmts.keys()):
-#             logger.info(f"Dumping new statements cache to {STMTS_PKL}")
-#             with Path(STMTS_PKL).open('wb') as f:
-#                 pickle.dump(obj=STMT_CACHE, file=f)
-
-#     # Combine statements with pairs, expand Complexes
-#     stmts_by_pair = {}
-#     for pair, hash_list in tqdm(hashes_by_pair.items()):
-#         stmt_by_dir = StmtsByDirectness(directed={}, undirected=defaultdict(list))
-#         for h, st in zip(hash_list, (stmt_by_hash.get(h) for h in hash_list)):
-#             if st is None:
-#                 logger.warning(f"No statement for hash {h}")
-#                 continue
-
-#             if isinstance(st, Complex):
-#                 cplx_stmts = expand_complex(st)
-#                 stmt_by_dir.undirected[h].extend(cplx_stmts)
-#             else:
-#                 stmt_by_dir.directed[h] = st
-#         if stmt_by_dir.has_data():
-#             stmts_by_pair[pair] = stmt_by_dir
-#     return stmts_by_pair

--- a/go_networks/util.py
+++ b/go_networks/util.py
@@ -1,10 +1,13 @@
 import logging
 import pickle
 from pathlib import Path
-from typing import List
+from typing import List, Dict, Optional
 
 import boto3
 import pandas as pd
+from ndex2 import Ndex2
+
+from indra.databases import ndex_client
 from indra.statements import *
 from indra_db.cli.dump import Sif, S3Path, get_latest_dump_s3_path
 
@@ -13,6 +16,9 @@ __all__ = [
     "stmts_by_directedness",
     "DIRECTED_TYPES",
     "UNDIRECTED_TYPES",
+    "NDEX_ARGS",
+    "get_ndex_web_client",
+    "get_networks_in_set",
 ]
 
 
@@ -70,6 +76,32 @@ def stmts_by_directedness(directed: bool) -> List[str]:
 # statement types by directedness
 DIRECTED_TYPES = stmts_by_directedness(True)
 UNDIRECTED_TYPES = stmts_by_directedness(False)
+
+
+NDEX_BASE_URL = "http://public.ndexbio.org"
+
+
+def _get_default_ndex_args() -> Dict[str, str]:
+    usr, pwd = ndex_client.get_default_ndex_cred(ndex_cred=None)
+    return {"username": usr, "password": pwd, "server": NDEX_BASE_URL}
+
+
+NDEX_ARGS = _get_default_ndex_args()
+
+
+def get_ndex_web_client() -> Ndex2:
+    return Ndex2(
+        **{(k if k != "server" else "host"): v for k, v in NDEX_ARGS.items()}
+    )
+
+
+def get_networks_in_set(network_set_id: str, client: Optional[Ndex2]) -> List[str]:
+    """Get the UUIDs of the networks in a network set."""
+    if client is None:
+        client = get_ndex_web_client()
+    network_set = client.get_networkset(network_set_id)
+    return network_set["networks"]
+
 
 # def set_directed(sif_df: pd.DataFrame):
 #     """Extend dataframe with column "directed" indicting directedness

--- a/go_networks/util.py
+++ b/go_networks/util.py
@@ -2,8 +2,6 @@ import logging
 from pathlib import Path
 from typing import List, Dict, Optional
 
-import boto3
-import pandas as pd
 from ndex2 import Ndex2
 
 from indra.databases import ndex_client
@@ -75,12 +73,12 @@ NDEX_ARGS = _get_default_ndex_args()
 
 
 def get_ndex_web_client() -> Ndex2:
-    return Ndex2(
-        **{(k if k != "server" else "host"): v for k, v in NDEX_ARGS.items()}
-    )
+    return Ndex2(**{(k if k != "server" else "host"): v for k, v in NDEX_ARGS.items()})
 
 
-def get_networks_in_set(network_set_id: str, client: Optional[Ndex2]) -> List[str]:
+def get_networks_in_set(
+    network_set_id: str, client: Optional[Ndex2] = None
+) -> List[str]:
     """Get the UUIDs of the networks in a network set."""
     if client is None:
         client = get_ndex_web_client()


### PR DESCRIPTION
This PR replaces the file dump framework with one based on INDRA CoGEx.

In this implementation, loading the data from scratch without any caching takes ~11 mins. With everything cached, the generation of networks takes ~1 min.

Other improvements:
- Make a cli for easier use. One for production, one for testing.
- Add some new styling of the graphs
- Update existing networks instead of creating new ones. Only create new ones if the network doesn't exist in the set

Running the cli
--------------------
```sh
python -m go_networks test|run
```