### PR TITLE
GO updates

### DIFF
--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -21,7 +21,7 @@ from go_networks.generate_v2 import main as gen_networks
 import click
 
 
-TEST_SET = "5f4a543a-0a85-11f0-9806-005056ae3c32"
+TEST_SET = "7de56fee-0f3f-11f0-9806-005056ae3c32"
 STYLE_NX = "4c2006cd-9fef-11ec-b3be-0ac135e8bacf"
 PROD_SET = "bdba6a7a-488a-11ec-b3be-0ac135e8bacf"
 SECONDARY_SET = "303190ca-aac0-11ec-b3be-0ac135e8bacf"
@@ -67,8 +67,8 @@ def test(
     style_network: str,
     ndex_server_style: str = "http://ndexbio.org",
 ):
-    """Build a test network for the test set 5f4a543a-0a85-11f0-9806-005056ae3c32"""
-    # Use the new test network set: 5f4a543a-0a85-11f0-9806-005056ae3c32
+    """Build a test network for the test set """
+    # Use the new test network set
     if TEST_SET == PROD_SET:
         click.secho("Test set and prod set are the same! Aborting...", fg="red")
     gen_networks(

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -4,6 +4,7 @@ import click
 
 
 TEST_SET = "d7acdc1d-a08f-11ec-b3be-0ac135e8bacf"
+NEW_TEST_SET = "5f4a543a-0a85-11f0-9806-005056ae3c32"
 STYLE_NX = "4c2006cd-9fef-11ec-b3be-0ac135e8bacf"
 PROD_SET = "bdba6a7a-488a-11ec-b3be-0ac135e8bacf"
 SECONDARY_SET = "303190ca-aac0-11ec-b3be-0ac135e8bacf"
@@ -49,11 +50,12 @@ def test(
     style_network: str,
     ndex_server_style: str = "http://ndexbio.org",
 ):
-    """Build a test network."""
-    # Use the test network set:
-    # d7acdc1d-a08f-11ec-b3be-0ac135e8bacf
+    """Build a test network for the test set 5f4a543a-0a85-11f0-9806-005056ae3c32"""
+    # Use the new test network set: 5f4a543a-0a85-11f0-9806-005056ae3c32
+    if NEW_TEST_SET == PROD_SET:
+        click.secho("Test set and prod set are the same! Aborting...", fg="red")
     gen_networks(
-        network_set=TEST_SET,
+        network_set=NEW_TEST_SET,
         style_network=style_network,
         regenerate=regenerate_props,
         test_go_term=go_term,

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -3,8 +3,7 @@ from go_networks.generate_v2 import main as gen_networks
 import click
 
 
-TEST_SET = "d7acdc1d-a08f-11ec-b3be-0ac135e8bacf"
-NEW_TEST_SET = "5f4a543a-0a85-11f0-9806-005056ae3c32"
+TEST_SET = "5f4a543a-0a85-11f0-9806-005056ae3c32"
 STYLE_NX = "4c2006cd-9fef-11ec-b3be-0ac135e8bacf"
 PROD_SET = "bdba6a7a-488a-11ec-b3be-0ac135e8bacf"
 SECONDARY_SET = "303190ca-aac0-11ec-b3be-0ac135e8bacf"
@@ -52,10 +51,10 @@ def test(
 ):
     """Build a test network for the test set 5f4a543a-0a85-11f0-9806-005056ae3c32"""
     # Use the new test network set: 5f4a543a-0a85-11f0-9806-005056ae3c32
-    if NEW_TEST_SET == PROD_SET:
+    if TEST_SET == PROD_SET:
         click.secho("Test set and prod set are the same! Aborting...", fg="red")
     gen_networks(
-        network_set=NEW_TEST_SET,
+        network_set=TEST_SET,
         style_network=style_network,
         regenerate=regenerate_props,
         test_go_term=go_term,

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -86,6 +86,11 @@ def run(
     network_set: str,
 ):
     """Run the go network generation."""
+    click.secho(
+        f"Generating networks for "
+        f"{'production ' if network_set == PROD_SET else ''}set ({network_set})",
+        fg="green",
+    )
     gen_networks(
         network_set=network_set,
         style_network=style_network,

--- a/go_networks/cli.py
+++ b/go_networks/cli.py
@@ -1,3 +1,21 @@
+"""CLI for updating the go_networks
+
+This module provides a command line interface (CLI) for generating and updating
+the go_networks. It uses the `click` library to define commands and options.
+It allows users to generate networks for specific Gene Ontology (GO) terms,
+using a specified style network and other parameters.
+
+Usage:
+
+    python -m go_networks.cli test|run [OPTIONS]
+
+Commands:
+
+    test: Build a test network for the test set
+    run: Run the go network generation for a specified network set.
+
+"""
+
 from go_networks.generate_v2 import main as gen_networks
 
 import click

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -8,6 +8,7 @@ import sys
 from collections import defaultdict
 from datetime import datetime, UTC
 from itertools import combinations
+from pathlib import Path
 from textwrap import dedent
 from time import sleep
 from typing import Dict, Iterator, Optional, Set, Tuple, Union, List
@@ -636,6 +637,58 @@ def get_go_uuid_mapping(set_uuid: str, request_retries: int = 3) -> Dict[str, st
         if go_id is None:
             logger.warning(f"No GO ID found for network {cx_uuid}")
     return go_uuid_mapping
+
+
+def get_go_uuid_mapping_from_local_cache(
+    local_cache: Union[Path, str]
+) -> Dict[str, str]:
+    """Get the mapping of GO IDs to UUIDs from a local cache
+
+    Parameters
+    ----------
+    local_cache :
+        The path to the local cache directory containing pickled NCX files. This
+        should be a directory where each file is named <uuid>.pkl and contains
+        a pickled `NiceCXNetwork` object. The parameter can be a `Path` or a
+        string.
+
+    Returns
+    -------
+    :
+        A mapping from GO IDs to UUIDs based on the contents of the local cache.
+    """
+    # Assuming the cache contains pickled NDEX graph objects, named <uuid>.pkl
+    mapping = {}
+    local_cache = Path(local_cache)
+    for ncx_path in tqdm(
+        list(local_cache.glob("*.pkl")),
+        desc="Loading local GO-UUID mapping", unit_scale=True
+    ):
+        # Load the cached ncx file and extract the GO ID
+        with ncx_path.open("rb") as f:
+            ncx: ndex2.NiceCXNetwork = pickle.load(f)
+
+        go_id = None
+        prop_dict = ncx.get_network_attribute("GO ID")
+        if prop_dict.get("n") and prop_dict["n"] == "GO ID":
+            go_id = prop_dict["v"]
+
+        if go_id is None:
+            logger.warning(f"No GO ID found in cached network {ncx_path.name}")
+            continue
+
+        # Map the GO ID to the UUID
+        uuid = ncx_path.stem
+
+        if go_id in mapping:
+            tqdm.write(
+                f"WARNING: Duplicate GO ID found: {go_id} for UUIDs {mapping[go_id]} "
+                f"and {uuid}. Overwriting to keep the latest one."
+            )
+        mapping[go_id] = uuid
+
+    logger.info(f"Loaded {len(mapping)} GO ID to UUID mappings from local cache")
+    return mapping
 
 
 def update_coordinates_for_network_set(set_uuid: str):

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -48,8 +48,9 @@ NCX_CACHE = cache.module("ncx_cache")
 DEFAULT_NDEX_SERVER = "http://ndexbio.org"
 TEST_GO_ID = None
 
-min_gene_count = 5
-max_gene_count = 200
+MIN_GENE_COUNT = 5
+MAX_GENE_COUNT = 200
+DB_SOURCES = ["biogrid", "hprd", "signor", "phosphoelm", "signor", "biopax"]
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +143,7 @@ def get_sif_from_cogex(limit: Optional[int] = None, with_apoc: bool = True) -> p
         gene1 <> gene2 AND
         // Filter out non-HGNC nodes
         gene1.id CONTAINS 'hgnc' AND
-        gene2.id CONTAINS 'hgnc' AND
-        // Filter out relations with only one evidence and from a reader
-        NOT (r.evidence_count = 1 AND r.has_reader_evidence)
+        gene2.id CONTAINS 'hgnc'
         {apoc_filter}
     RETURN gene1, gene2, r.belief, r.evidence_count, r.source_counts, r.stmt_hash, r.stmt_type
     """)
@@ -156,10 +155,17 @@ def get_sif_from_cogex(limit: Optional[int] = None, with_apoc: bool = True) -> p
             "WITH gene1, gene2, r, "
             "apoc.convert.fromJsonMap(r.source_counts) AS source_counts"
         )
-        apoc_filter = (
-            "// Filter out Complex statements with only sparser as source\n"
-            "    AND NOT (r.stmt_type = 'Complex' AND keys(source_counts) = ['sparser'])"
-        )
+        apoc_filter = dedent(f"""\
+            // Filter out Complex statements with only sparser as source
+            AND NOT (r.stmt_type = 'Complex' AND keys(source_counts) = ['sparser'])
+            // Filter out relations with only one evidence and from a reader
+            AND NOT (
+                r.evidence_count = 1 AND
+                NOT apoc.coll.intersection(
+                    keys(source_counts),
+                    {DB_SOURCES}
+                )
+            )""")
     else:
         apoc_filter = ""
         apoc_with_clause = ""
@@ -190,6 +196,10 @@ def get_sif_from_cogex(limit: Optional[int] = None, with_apoc: bool = True) -> p
             # Filter out Complex statements with only sparser as source
             source_counts = json.loads(r[4])
             if r[6] == "Complex" and {"sparser"} == set(source_counts):
+                continue
+            # Filter out relations with only one evidence and from a reader
+            # (i.e. not in DB_SOURCES)
+            if int(r[3]) == 1 and not set(source_counts).intersection(DB_SOURCES):
                 continue
         res_tuples.append(
             (
@@ -477,7 +487,7 @@ def filter_go_ids(go2genes_map) -> Dict[str, Set[str]]:
     return {
         go_id: genes
         for go_id, genes in tqdm(go2genes_map.items(), desc="Filtering GO IDs")
-        if min_gene_count <= len(genes) <= max_gene_count
+        if MIN_GENE_COUNT <= len(genes) <= MAX_GENE_COUNT
     }
 
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -1113,6 +1113,7 @@ def make_network_public_and_visible(
             "readOnly": True
         },
         ndex_client=ndex_client,
+        attempts=attempts,
     )
     return res
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -403,11 +403,13 @@ def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
     logger.info("Adding genes of child terms to the parent terms")
     bio_ontology.initialize()
 
-    # For each term, add the genes associated with its children as well
-    for go_id in tqdm(set(genes_by_go.keys()), desc="Adding genes of child terms"):
+    # For each term, add the genes associated with it to its parents as well
+    for go_id in tqdm(set(genes_by_go), desc="Adding genes to parent terms"):
         # children come out as ('GO', 'GO:0001234'), use only GO:0001234
-        for db_ns, go_child in bio_ontology.get_children("GO", go_id.upper()):
-            genes_by_go[go_id] |= genes_by_go[go_child]
+        assert go_id.isupper()
+        for db_ns, go_parent in bio_ontology.get_parents("GO", go_id):
+            assert go_parent.isupper()
+            genes_by_go[go_parent] |= genes_by_go[go_id]
 
     # Reset defaultdict to dict
     genes_by_go = dict(genes_by_go)

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -14,6 +14,7 @@ import ndex2.client
 import pandas as pd
 import pystow
 from neo4j.exceptions import CypherSyntaxError
+from requests import ReadTimeout
 from indra.ontology.bio import bio_ontology
 from indra_cogex.client.neo4j_client import Neo4jClient
 from indra_db.client.principal.curation import get_curations
@@ -562,13 +563,16 @@ def get_ncx_cache_from_set(ncx_set_uuid: str, refresh=False):
     return ncx_cache
 
 
-def get_go_uuid_mapping(set_uuid: str) -> Dict[str, str]:
+def get_go_uuid_mapping(set_uuid: str, request_retries: int = 3) -> Dict[str, str]:
     """Get mapping of GO IDs to UUID from NDEx
 
     Parameters
     ----------
     set_uuid :
         The UUID of the GO set
+    request_retries :
+        Number of retries per requests in case of timeouts. Default is 3. If more than
+        this many retries are needed, an error is raised.
 
     Returns
     -------
@@ -582,10 +586,18 @@ def get_go_uuid_mapping(set_uuid: str) -> Dict[str, str]:
     uuid_set = get_networks_in_set(network_set_id=set_uuid, client=ndex_web_client)
     go_uuid_mapping = {}
 
-    logger.info("Getting GO ID-uuid mapping")
-    for cx_uuid in tqdm(uuid_set):
+    for cx_uuid in tqdm(uuid_set, desc="Getting GO-UUID mapping"):
         # Get the info for the network
-        network_info = ndex_web_client.get_network_summary(cx_uuid)
+        for attempt in range(request_retries):
+            try:
+                network_info = ndex_web_client.get_network_summary(cx_uuid)
+                break
+            except ReadTimeout:
+                if attempt < request_retries - 1:
+                    tqdm(f"Read timeout for network {cx_uuid}, retrying...")
+                    sleep(1.25)
+                else:
+                    raise
 
         # Get the go id
         go_id = None

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -922,12 +922,13 @@ def main(
     failed_to_set_public = []
     failed_to_update = []
     logger.info(f"Uploading {len(networks)} networks to NDEx")
-    for go_id, network_dict in tqdm(sorted(networks.items(), key=lambda x: x[0])):
+    for go_id, network_dict in tqdm(sorted(networks.items(), key=lambda x: x[0]),
+                                    desc="Uploading networks"):
         network = network_dict["network"]
         min_score = network_dict["min_score"]
         max_score = network_dict["max_score"]
 
-        # Update style network
+        # Update style network to match the scores of the current network
         _update_style_network(style_ncx, min_score=min_score, max_score=max_score)
 
         # Get uuid for GO term

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -925,11 +925,85 @@ def delete_networks(network_uuids: Set[str], ndex_client: ndex2.Ndex2):
     return failed
 
 
+def set_network_system_properties(
+    uuid: str,
+    system_properties: Dict[str, Union[bool, str]],
+    ndex_client: Optional[ndex2.Ndex2] = None,
+    attempts: int = 3
+) -> str:
+    """Set the system properties for a network
+
+    Parameters
+    ----------
+    uuid :
+        The UUID of the network to set the system properties for.
+    system_properties :
+        A dictionary of system properties to set for the network. The keys and their
+        values should be any of:
+        - readOnly: (boolean : True or False)
+        - index_level: (str : 'NONE', 'META', or 'ALL')
+        - visibility: (str : 'public', 'private', or 'hidden')
+        - showcase: (boolean : True or False)
+    ndex_client :
+        The ndex client to use for making the network writable. If None, a new
+        client will be created using `get_ndex_web_client()` for this call only.
+    attempts :
+        The number of attempts to retry setting the network system properties in case of
+        network issues. Default is 3. If more than this many attempts fail, an error will
+        be raised.
+
+    Returns
+    -------
+    :
+        The response from the NDEx API after setting the network properties.
+    """
+    if not system_properties:
+        raise ValueError("system_properties must be provided and cannot be empty")
+
+    if not set(system_properties.keys()) & {"readOnly", "index_level", "visibility",
+                                            "showcase"}:
+        raise ValueError(
+            "At least one of the following keys must be provided in system_properties: "
+            "`readOnly`, `index_level`, `visibility`, `showcase`"
+        )
+
+    if ndex_client is None:
+        ndex_client = get_ndex_web_client()
+
+    for attempt in range(attempts):
+        try:
+            res = ndex_client.set_network_system_properties(
+                network_id=uuid,
+                network_properties=system_properties
+            )
+            return res  # Return the response if successful
+        except Exception as e:
+            if attempt < attempts - 1:
+                # Retry on failure
+                tqdm.write(
+                    f"Attempt {attempt + 1} to make network {uuid} writable failed: {e}. "
+                    f"Retrying..."
+                )
+                sleep(1)
+            else:
+                # Failed after all attempts
+                tqdm.write(
+                    f"Failed to make network {uuid} writable after {attempts} attempts: "
+                    f"{e}. Please check the network manually."
+                )
+                raise e
+
+    raise RuntimeError(
+        f"WARNING: Ended retry loop in set_network_system_properties for uuid "
+        f"{uuid}. This should not happen, please check the logic."
+    )
+
+
 def make_network_writable(
     uuid: str,
     ndex_client: Optional[ndex2.Ndex2] = None,
     attempts: int = 3
-) -> bool:
+) -> str:
     """Change the network properties to make it writable.
 
     Parameters
@@ -945,106 +1019,65 @@ def make_network_writable(
 
     Returns
     -------
-
+    :
+        Response from the NDEx API after setting the network properties.
     """
     if ndex_client is None:
         ndex_client = get_ndex_web_client()
 
-    for attempt in range(attempts):
-        try:
-            res = ndex_client.set_network_system_properties(
-                network_id=uuid,
-                network_properties={
-                    # Make the network writable
-                    "readOnly": False
-                }
-            )
-            success = True
-            return success
-        except Exception as e:
-            if attempt < attempts - 1:
-                # Retry on failure
-                tqdm.write(
-                    f"Attempt {attempt + 1} to make network {uuid} writable failed: {e}. "
-                    f"Retrying..."
-                )
-                sleep(1)
-            else:
-                # Failed after all attempts
-                tqdm.write(
-                    f"Failed to make network {uuid} writable after {attempts} attempts: {e}. "
-                    f"Please check the network manually."
-                )
-                return False
-
-    # We should not reach this point, but print a message just in case
-    tqdm.write(f"WARNING: Ended loop in make_network_writable for uuid {uuid}. "
-               f"This should not happen, please check the logic.")
-    return False
+    return set_network_system_properties(
+        uuid=uuid,
+        system_properties={
+            # Make the network writable
+            "readOnly": False,
+        },
+        ndex_client=ndex_client,
+        attempts=attempts,
+    )
 
 
 def make_network_readonly(
     uuid: str,
     ndex_client: Optional[ndex2.Ndex2] = None,
     attempts: int = 3
-) -> bool:
-    """Change the network properties to make it writable.
+) -> str:
+    """Change the network properties to make it readonly.
 
     Parameters
     ----------
     uuid :
-        The UUID of the network to make writable.
+        The UUID of the network to make readonly.
     ndex_client :
-        The ndex client to use for making the network writable. If None, a new
+        The ndex client to use for making the network readonly. If None, a new
         client will be created using `get_ndex_web_client()` for this call only.
     attempts :
-        The number of attempts to retry making the network writable in case of
+        The number of attempts to retry making the network readonly in case of
         network issues. Default is 3.
 
     Returns
     -------
-
+    :
+        Response from the NDEx API after setting the network properties.
     """
     if ndex_client is None:
         ndex_client = get_ndex_web_client()
 
-    for attempt in range(attempts):
-        try:
-            res = ndex_client.set_network_system_properties(
-                network_id=uuid,
-                network_properties={
-                    # Make the network writable
-                    "readOnly": True
-                }
-            )
-            return True
-        except Exception as e:
-            if attempt < attempts - 1:
-                # Retry on failure
-                tqdm.write(
-                    f"Attempt {attempt + 1} to make network {uuid} writable failed: {e}. "
-                    f"Retrying..."
-                )
-                sleep(1)
-            else:
-                # Failed after all attempts
-                tqdm.write(
-                    f"Failed to make network {uuid} writable after {attempts} attempts: {e}. "
-                    f"Please check the network manually."
-                )
-                return False
-
-    # We should not reach this point, but print a message just in case
-    tqdm.write(f"WARNING: Ended loop in make_network_writable for uuid {uuid}. "
-               f"This should not happen, please check the logic.")
-    return False
+    return set_network_system_properties(
+        uuid=uuid,
+        system_properties={
+            # Make the network readonly
+            "readOnly": True,
+        },
+        ndex_client=ndex_client,
+        attempts=attempts,
+    )
 
 
 def make_network_public_and_visible(
     uuid: str,
     ndex_client: Optional[ndex2.Ndex2] = None,
     attempts: int = 3
-) -> bool:
+) -> str:
     """Make a network public and visible on NDEx.
 
     Parameters
@@ -1065,43 +1098,23 @@ def make_network_public_and_visible(
     if ndex_client is None:
         ndex_client = get_ndex_web_client()
 
-    for attempt in range(attempts):
-        try:
-            res = ndex_client.set_network_system_properties(
-                network_id=uuid,
-                network_properties={
-                    # Showcase: network will display on the home page for other users
-                    "showcase": True,
-                    # PUBLIC: Network can be found or read by anyone
-                    "visibility": "PUBLIC",
-                    # "Full index on the network" (unclear, but was recommended by
-                    # the ndex group)
-                    "index_level": "ALL",
-                    # Readonly access makes any attempt to edit the network fail,
-                    # Has to be set to False before delete or update.
-                    "readOnly": True
-                }
-            )
-            return True
-        except Exception as e:
-            if attempt < attempts - 1:
-                # Retry on failure
-                tqdm.write(
-                    f"Attempt {attempt + 1} to make network {uuid} public failed: {e}. "
-                    f"Retrying..."
-                )
-                sleep(1)
-            else:
-                tqdm.write(
-                    f"Failed to make network {uuid} public after {attempts} attempts: {e}. "
-                    f"Please check the network manually."
-                )
-                return False
-
-    # We shouldn't reach this point
-    tqdm.write(f"WARNING: Ended loop in make_network_public_and_visible for uuid "
-               f"{uuid}. This should not happen, please check the logic.")
-    return False
+    res = set_network_system_properties(
+        uuid=uuid,
+        system_properties={
+            # Showcase: network will display on the home page for other users
+            "showcase": True,
+            # PUBLIC: Network can be found or read by anyone
+            "visibility": "PUBLIC",
+            # "Full index on the network" (unclear, but was recommended by
+            # the ndex group)
+            "index_level": "ALL",
+            # Readonly access makes any attempt to edit the network fail,
+            # Has to be set to False before delete or update.
+            "readOnly": True
+        },
+        ndex_client=ndex_client,
+    )
+    return res
 
 
 def format_and_update_network(

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -1,6 +1,7 @@
 """
 Generate GO Networks from a list of GO terms and the Sif dump.
 """
+import json
 import logging
 import pickle
 from collections import defaultdict
@@ -12,6 +13,7 @@ from typing import Dict, Iterator, Optional, Set, Tuple, Union, List
 import ndex2.client
 import pandas as pd
 import pystow
+from neo4j.exceptions import CypherSyntaxError
 from indra.ontology.bio import bio_ontology
 from indra_cogex.client.neo4j_client import Neo4jClient
 from indra_cogex.representation import Node
@@ -109,7 +111,7 @@ def get_curation_set() -> Set[int]:
     return hashes_out
 
 
-def get_sif_from_cogex(limit: Optional[int] = None) -> pd.DataFrame:
+def get_sif_from_cogex(limit: Optional[int] = None, with_apoc: bool = True) -> pd.DataFrame:
     """Get the SIF from the database
 
     Conditions:
@@ -117,47 +119,78 @@ def get_sif_from_cogex(limit: Optional[int] = None) -> pd.DataFrame:
         - Only HGNC nodes
         - Skip relations where evidence_count == 1 AND source is a reader
         - Skip relations where stmt_type == 'Complex' AND sparser is the only
-          source
+          source, for any evidence count
 
     Parameters
     ----------
     limit :
         Limit the number of edges to return. Useful for testing or debugging.
+    with_apoc :
+        If True, use the apoc library to perform some of the filtering directly
+        in the query. If False, perform that filtering in Python.
 
     Returns
     -------
     :
         A pandas DataFrame with the SIF data
     """
-    query = dedent(
-        """
+    query_fmt = dedent("""\
     MATCH (gene1:BioEntity)-[r:indra_rel]-(gene2:BioEntity)
-    WITH gene1, gene2, r, apoc.convert.fromJsonMap(r.source_counts) AS source_counts
+    {apoc_with_clause}
     WHERE
+        // Filter out self loops
         gene1 <> gene2 AND
+        // Filter out non-HGNC nodes
         gene1.id CONTAINS 'hgnc' AND
         gene2.id CONTAINS 'hgnc' AND
-        NOT (r.stmt_type = 'Complex' AND keys(source_counts) = ['sparser']) AND
-        NOT (
-            r.evidence_count = 1 AND
-            NOT apoc.coll.intersection(
-                keys(source_counts),
-                ["biogrid", "hprd", "signor", "phosphoelm", "signor", "biopax"]
-            )
-        )
+        // Filter out relations with only one evidence and from a reader
+        NOT (r.evidence_count = 1 AND r.has_reader_evidence)
+        {apoc_filter}
     RETURN gene1, gene2, r.belief, r.evidence_count, r.source_counts, r.stmt_hash, r.stmt_type
-    """
-    )
+    """)
     if limit is not None and isinstance(limit, int):
-        query += f"LIMIT {limit}"
+        query_fmt += f"LIMIT {limit}"
+
+    if with_apoc:
+        apoc_with_clause = (
+            "WITH gene1, gene2, r, "
+            "apoc.convert.fromJsonMap(r.source_counts) AS source_counts"
+        )
+        apoc_filter = (
+            "// Filter out Complex statements with only sparser as source\n"
+            "    AND NOT (r.stmt_type = 'Complex' AND keys(source_counts) = ['sparser'])"
+        )
+    else:
+        apoc_filter = ""
+        apoc_with_clause = ""
+
+    query = query_fmt.format(
+        apoc_with_clause=apoc_with_clause, apoc_filter=apoc_filter
+    )
+
     n4j_client = Neo4jClient()
     logger.info("Getting SIF interaction data from database")
-    results = n4j_client.query_tx(query)
+    if with_apoc:
+        try:
+            results = n4j_client.query_tx(query)
+        except CypherSyntaxError:
+            logger.warning("Failed to get SIF from database with apoc query, trying without")
+            with_apoc = False
+            query = query_fmt.format(apoc_with_clause="", apoc_filter="")
+
+    if not with_apoc:
+        results = n4j_client.query_tx(query)
+
     res_tuples = []
     logger.info("Generating SIF from database results")
     for r in tqdm(results):
         gene1 = n4j_client.neo4j_to_node(r[0])
         gene2 = n4j_client.neo4j_to_node(r[1])
+        if not with_apoc:
+            # Filter out Complex statements with only sparser as source
+            source_counts = json.loads(r[4])
+            if r[6] == "Complex" and {"sparser"} == set(source_counts):
+                continue
         res_tuples.append(
             (
                 gene1.db_ns,  # agA_ns

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -1125,9 +1125,27 @@ def format_and_update_network(
     if cx_uuid:
         for attempt in range(retries):
             try:
+
+                # Make network read/write before updating it, otherwise this will fail
+                success = make_network_writable(
+                    cx_uuid,
+                    ndex_client=ndex_client,
+                    attempts=1
+                )
+                if not success:
+                    raise Exception("Failed to make network writable before updating.")
                 ndex_client.update_cx_network(
                     cx_stream=ncx.to_cx_stream(), network_id=cx_uuid
                 )
+
+                # Successfully updated the network, now make it readonly again
+                success = make_network_readonly(
+                    cx_uuid,
+                    ndex_client=ndex_client,
+                    attempts=1
+                )
+                if not success:
+                    raise Exception("Failed to make network readonly after updating.")
                 break
             except Exception as e:
                 if attempt < retries - 1:
@@ -1157,17 +1175,12 @@ def format_and_update_network(
 
         # Make the network public
         if not failed_update:
-            for attempt in range(retries):
-                try:
-                    ndex_client.make_network_public(network_id)
-                    break
-                except Exception as e:
-                    if attempt < retries - 1:
-                        sleep(1)
-                    else:
-                        tqdm.write(f"Warning: failed to make network "
-                                   f"{network_id} public: {e}")
-                        failed_public = True
+            # This sets the network to read-only
+            successful = make_network_public_and_visible(
+                network_id, attempts=retries
+            )
+            if not successful:
+                failed_public = True
 
         for attempt in range(retries):
             try:

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -414,6 +414,30 @@ def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
     # Reset defaultdict to dict
     genes_by_go = dict(genes_by_go)
 
+    # DEBUG section
+    import requests
+    def get_gene_number_web(go_term, indirect):
+        node_jsons = requests.post(
+                'https://discovery.indra.bio/api/get_genes_for_go_term',
+                json={"go_term": ["GO", go_term], "include_indirect": indirect}
+        ).json()
+        return {jd["data"]["name"] for jd in node_jsons}
+    for go_id, genes in tqdm(genes_by_go.items(), desc="Checking gene counts against CoGEx"):
+        cogex_set = get_gene_number_web(go_id, indirect=True)
+        if genes != cogex_set:
+            import ipdb
+            tqdm.write("WARNING: "
+                f"Mismatch in gene counts for {go_id}: "
+                f"local count {len(genes)} vs CoGEx count {len(cogex_set)}. "
+                f"Investigating with IPDB."
+            )
+            # Drop into ipdb to investigate
+            ipdb.set_trace()
+            raise RuntimeError(
+                f"Mismatch in gene counts between local and CoGEx for {go_id}. Please "
+                "investigate."
+            )
+
     # Save to cache
     with GO_MAPPINGS.open(mode="wb") as fw:
         logger.info("Caching GO mappings")

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -392,12 +392,15 @@ def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
     logger.info("Loading GO mapping from database")
 
     # Set initial mapping
-    genes_by_go = defaultdict(set)
+    genes_by_go = {}
     for go_curie, gene_symbol in tqdm(go_term_gene_query(),
                                       desc="Loading GO-gene associations"):
-        # Use upper case for GO IDs so we get GO:0001234 instead of go:0001234 so that
-        # it corresponds to the bio_ontology
-        genes_by_go[go_curie.upper()].add(gene_symbol)
+        # Use upper case for GO IDs so we get GO:0001234 instead of go:0001234 so we
+        # can match the case in the bio_ontology
+        if go_curie.upper() not in genes_by_go:
+            # Initialize the set for this go id
+            genes_by_go[go_curie.upper()] = set()
+        genes_by_go[go_curie].add(gene_symbol)
 
     # Load bio ontology
     logger.info("Adding genes of child terms to the parent terms")
@@ -409,34 +412,10 @@ def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
         assert go_id.isupper()
         for db_ns, go_parent in bio_ontology.get_parents("GO", go_id):
             assert go_parent.isupper()
+            if go_parent not in genes_by_go:
+                # If the parent doesn't exist in the mapping, initialize it
+                genes_by_go[go_parent] = set()
             genes_by_go[go_parent] |= genes_by_go[go_id]
-
-    # Reset defaultdict to dict
-    genes_by_go = dict(genes_by_go)
-
-    # DEBUG section
-    import requests
-    def get_gene_number_web(go_term, indirect):
-        node_jsons = requests.post(
-                'https://discovery.indra.bio/api/get_genes_for_go_term',
-                json={"go_term": ["GO", go_term], "include_indirect": indirect}
-        ).json()
-        return {jd["data"]["name"] for jd in node_jsons}
-    for go_id, genes in tqdm(genes_by_go.items(), desc="Checking gene counts against CoGEx"):
-        cogex_set = get_gene_number_web(go_id, indirect=True)
-        if genes != cogex_set:
-            import ipdb
-            tqdm.write("WARNING: "
-                f"Mismatch in gene counts for {go_id}: "
-                f"local count {len(genes)} vs CoGEx count {len(cogex_set)}. "
-                f"Investigating with IPDB."
-            )
-            # Drop into ipdb to investigate
-            ipdb.set_trace()
-            raise RuntimeError(
-                f"Mismatch in gene counts between local and CoGEx for {go_id}. Please "
-                "investigate."
-            )
 
     # Save to cache
     with GO_MAPPINGS.open(mode="wb") as fw:

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -982,7 +982,10 @@ def make_network_public_and_visible(
                 )
                 return False
 
-    return True
+    # We shouldn't reach this point
+    tqdm.write(f"WARNING: Ended loop in make_network_public_and_visible for uuid "
+               f"{uuid}. This should not happen, please check the logic.")
+    return False
 
 
 def format_and_update_network(

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -525,7 +525,13 @@ def generate(
     go2genes_map = genes_by_go_id(regenerate=regenerate)
 
     # Filter GO IDs
+    if TEST_GO_ID:
+        logger.info(f"{TEST_GO_ID} has {len(go2genes_map[TEST_GO_ID])} genes "
+                    f"associated with it.")
     go2genes_map = filter_go_ids(go2genes_map)
+    if TEST_GO_ID and TEST_GO_ID not in go2genes_map:
+        logger.warning(f"Test GO ID {TEST_GO_ID} was filtered out.")
+        sys.exit(1)
 
     # Generate properties
     sif_props = generate_props(regenerate=regenerate)

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -364,6 +364,8 @@ def go_term_gene_query() -> Iterator[Tuple[str, str]]:
     """
     query = (
         "MATCH (gene:BioEntity)-[:associated_with]->(term:BioEntity) "
+        "WHERE gene.id STARTS WITH 'HGNC:' "  # Somehow interpro shows up in the 
+        # results, filter it out by enforing HGNC ids
         "RETURN term.id, gene.name"
     )
     client = Neo4jClient()
@@ -559,13 +561,28 @@ def download_ncx_from_uuids(ncx_uuids):
 
 
 def get_ncx_cache_from_set(ncx_set_uuid: str, refresh=False):
-    """Get the set of ncx networks from a network set and cache them"""
+    """Get the set of ncx networks from a network set cache or from NDEX bio
+
+    Parameters
+    ----------
+    ncx_set_uuid : str
+        The UUID of the network set to load from the local cache or download
+        from NDEX if it doesn't exist locally.
+    refresh : bool
+        If True, refresh the cache by downloading the networks again from NDEX.
+
+    Returns
+    -------
+    ncx_cache : dict
+        A dictionary mapping UUIDs to their corresponding NiceCXNetwork objects.
+    """
     ncx_cache = {}
+    set_cache_path = NCX_CACHE.module(ncx_set_uuid)
     ndex_web_client = get_ndex_web_client()
     ncx_uuids = get_networks_in_set(ncx_set_uuid, client=ndex_web_client)
     for ncx_uuid in tqdm(ncx_uuids,
                          desc=f"Downloading NCX from set {ncx_set_uuid}"):
-        ncx_file = NCX_CACHE.join(name=f"{ncx_uuid}.pkl")
+        ncx_file = set_cache_path.join(name=f"{ncx_uuid}.pkl")
         if not refresh and ncx_file.is_file():
             with ncx_file.open("rb") as f:
                 ncx = pickle.load(f)

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -732,7 +732,30 @@ def add_to_new_set(add_from_set_uuid: str,
 def get_networks_and_date_for_user(
         user: str, ndex_client: Optional[ndex2.Ndex2] = None
 ) -> List[Dict[str, Union[datetime, str]]]:
-    """Get network UUIDs together with their creation and modification date"""
+    """Get network UUIDs together with their creation and modification date
+
+    Parameters
+    ----------
+    user :
+        The username for which to get the networks
+    ndex_client :
+        An optional NDEx client. If None, a new client will be created.
+
+    Returns
+    -------
+    :
+        A list of dictionaries containing the UUIDs and their creation and
+        modification times. Each dictionary will have the keys:
+            - "uuid": The UUID of the network
+            - "modificationTime": The datetime of the last modification
+            - "creationTime": The datetime of creation
+    """
+    def _get_go_id(props):
+        for prop in props:
+            if prop["predicateString"] == "GO ID":
+                return prop["value"]
+        return None
+
     def _get_dt(raw_ts: int) -> datetime:
         str_ts = str(raw_ts)
         return datetime.fromtimestamp(float(f"{str_ts[:10]}.{str_ts[10:]}"))
@@ -740,18 +763,25 @@ def get_networks_and_date_for_user(
     def _get_list(sums):
         out = []
         for s in sums:
-            out.append({"uuid": s["externalId"],
-                        "modificationTime": _get_dt(s["modificationTime"]),
-                        "creationTime": _get_dt(s["creationTime"])})
+            out.append(
+                {
+                    "uuid": s["externalId"],
+                    "modificationTime": _get_dt(s["modificationTime"]),
+                    "creationTime": _get_dt(s["creationTime"]),
+                    "go_id": _get_go_id(s["properties"]),
+                }
+            )
         return out
 
     # Get client if not provided
     if ndex_client is None:
         ndex_client = get_ndex_web_client()
 
+    t = tqdm(desc="Getting networks for user")
     res = []
     summaries = ndex_client.get_user_network_summaries(username=user)
     res += _get_list(summaries)
+    t.update()
 
     # If the returned list has 1000 entries, it was likely cut off and we
     # need to make a new request with a new offset
@@ -761,6 +791,8 @@ def get_networks_and_date_for_user(
                                                            offset=offset)
         res += _get_list(summaries)
         offset += 1000
+        t.update()
+    t.close()
 
     # Check for double counting
     uuids = set()

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -4,10 +4,12 @@ Generate GO Networks from a list of GO terms and the Sif dump.
 import json
 import logging
 import pickle
+import sys
 from collections import defaultdict
 from datetime import datetime, UTC
 from itertools import combinations
 from textwrap import dedent
+from time import sleep
 from typing import Dict, Iterator, Optional, Set, Tuple, Union, List
 
 import ndex2.client
@@ -821,6 +823,7 @@ def format_and_update_network(
     style_ncx: NiceCXNetwork,
     ndex_client: ndex2.client.Ndex2,
     cx_uuid: Optional[str] = None,
+    retries: int = 3,
 ) -> Tuple[str, Dict[str, bool]]:
     """Take a NiceCXNetwork and upload it to NDEx."""
     # Fixme: NiceCXNetwork.apply_style_from_network() does not exist in
@@ -830,34 +833,67 @@ def format_and_update_network(
     ncx.apply_style_from_network(style_ncx)
     failed_public = False
     failed_update = False
+
     # If we have a UUID, update the network
     if cx_uuid:
-        try:
-            ndex_client.update_cx_network(
-                cx_stream=ncx.to_cx_stream(), network_id=cx_uuid
-            )
-        except Exception as e:
-            logger.warning(f"Failed to update network {cx_uuid}: {e}")
-            failed_update = True
-        finally:
-            network_id = cx_uuid
+        for attempt in range(retries):
+            try:
+                ndex_client.update_cx_network(
+                    cx_stream=ncx.to_cx_stream(), network_id=cx_uuid
+                )
+                break
+            except Exception as e:
+                if attempt < retries - 1:
+                    sleep(1)
+                else:
+                    tqdm.write(f"Failed to update network {cx_uuid}: {e}")
+                    failed_update = True
+
+        network_id = cx_uuid
+
     # If there is no UUID, create a new network
     else:
-        network_url = ncx.upload_to(client=ndex_client)
-        network_id = network_url.split("/")[-1]
-        try:
-            ndex_client.make_network_public(network_id)
-        except Exception as e:
-            logger.warning(f"Failed to make network {network_id} public: {e}")
-            failed_public = True
+        # Upload/create new network
+        for attempt in range(retries):
+            try:
+                network_url = ncx.upload_to(client=ndex_client)
+                network_id = network_url.split("/")[-1]
+                break
+            except Exception as e:
+                if attempt < retries - 1:
+                    sleep(1)
+                else:
+                    tqdm.write(
+                        f"Warning: failed to upload new network {cx_uuid}: {e}"
+                    )
+                    failed_update = True
 
-        try:
-            ndex_client.add_networks_to_networkset(network_set_id, [network_id])
-        except Exception as e:
-            logger.warning(
-                f"Failed to add network {network_id} to network set "
-                f"{network_set_id}: {e}"
-            )
+        # Make the network public
+        if not failed_update:
+            for attempt in range(retries):
+                try:
+                    ndex_client.make_network_public(network_id)
+                    break
+                except Exception as e:
+                    if attempt < retries - 1:
+                        sleep(1)
+                    else:
+                        tqdm.write(f"Warning: failed to make network "
+                                   f"{network_id} public: {e}")
+                        failed_public = True
+
+        for attempt in range(retries):
+            try:
+                ndex_client.add_networks_to_networkset(network_set_id, [network_id])
+                break
+            except Exception as e:
+                if attempt < retries - 1:
+                    sleep(1)
+                else:
+                    tqdm.write(
+                        f"Warning: failed to add network {network_id} to network"
+                        f"set {network_set_id}: {e}"
+                    )
 
     return network_id, {"public": failed_public, "update": failed_update}
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -885,7 +885,7 @@ def get_networks_before_date_for_user(
 ):
     """Get all networks created and modified before the provided date"""
     # Check that the cutoff date is valid
-    utcnow = datetime.utcnow()
+    utcnow = datetime.now(UTC)
     if cutoff_date > utcnow:
         raise ValueError(
             f"Cutoff date is in the future (year={cutoff_date.year}, month="

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -16,7 +16,6 @@ import pystow
 from neo4j.exceptions import CypherSyntaxError
 from indra.ontology.bio import bio_ontology
 from indra_cogex.client.neo4j_client import Neo4jClient
-from indra_cogex.representation import Node
 from indra_db.client.principal.curation import get_curations
 from ndex2 import NiceCXNetwork, create_nice_cx_from_server
 from tqdm import tqdm

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -925,7 +925,7 @@ def delete_networks(network_uuids: Set[str], ndex_client: ndex2.Ndex2):
     return failed
 
 
-def set_network_system_properties(
+def set_network_properties(
     uuid: str,
     system_properties: Dict[str, Union[bool, str]],
     ndex_client: Optional[ndex2.Ndex2] = None,
@@ -994,7 +994,7 @@ def set_network_system_properties(
                 raise e
 
     raise RuntimeError(
-        f"WARNING: Ended retry loop in set_network_system_properties for uuid "
+        f"WARNING: Ended retry loop in set_network_properties for uuid "
         f"{uuid}. This should not happen, please check the logic."
     )
 
@@ -1025,7 +1025,7 @@ def make_network_writable(
     if ndex_client is None:
         ndex_client = get_ndex_web_client()
 
-    return set_network_system_properties(
+    return set_network_properties(
         uuid=uuid,
         system_properties={
             # Make the network writable
@@ -1062,7 +1062,7 @@ def make_network_readonly(
     if ndex_client is None:
         ndex_client = get_ndex_web_client()
 
-    return set_network_system_properties(
+    return set_network_properties(
         uuid=uuid,
         system_properties={
             # Make the network readonly
@@ -1098,7 +1098,7 @@ def make_network_public_and_visible(
     if ndex_client is None:
         ndex_client = get_ndex_web_client()
 
-    res = set_network_system_properties(
+    res = set_network_properties(
         uuid=uuid,
         system_properties={
             # Showcase: network will display on the home page for other users

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -347,7 +347,7 @@ def generate_props(
     return props_by_pair
 
 
-def go_term_gene_query() -> Iterator[Tuple[Node, Node]]:
+def go_term_gene_query() -> Iterator[Tuple[str, str]]:
     """An Iterator of go-term gene pairs
 
     Returns
@@ -356,13 +356,11 @@ def go_term_gene_query() -> Iterator[Tuple[Node, Node]]:
         An iterable of pairs of go term node with associated gene node
     """
     query = (
-        "MATCH (gene:BioEntity)-[:associated_with]->(term:BioEntity) RETURN term, gene"
+        "MATCH (gene:BioEntity)-[:associated_with]->(term:BioEntity) "
+        "RETURN term.id, gene.name"
     )
     client = Neo4jClient()
-    return (
-        (client.neo4j_to_node(r[0]), client.neo4j_to_node(r[1]))
-        for r in client.query_tx(query)
-    )
+    return client.query_tx(query)
 
 
 def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
@@ -388,8 +386,11 @@ def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
 
     # Set initial mapping
     genes_by_go = defaultdict(set)
-    for go_node, gene in tqdm(go_term_gene_query(), desc="Loading from database"):
-        genes_by_go[go_node.db_id].add(gene.data["name"])
+    for go_curie, gene_symbol in tqdm(go_term_gene_query(),
+                                      desc="Loading GO-gene associations"):
+        # Use upper case for GO IDs so we get GO:0001234 instead of go:0001234 so that
+        # it corresponds to the bio_ontology
+        genes_by_go[go_curie.upper()].add(gene_symbol)
 
     # Load bio ontology
     logger.info("Adding genes of child terms to the parent terms")
@@ -397,7 +398,8 @@ def genes_by_go_id(regenerate: bool = False) -> Dict[str, Set[str]]:
 
     # For each term, add the genes associated with its children as well
     for go_id in tqdm(set(genes_by_go.keys()), desc="Adding genes of child terms"):
-        for go_child in bio_ontology.get_children("GO", go_id):
+        # children come out as ('GO', 'GO:0001234'), use only GO:0001234
+        for db_ns, go_child in bio_ontology.get_children("GO", go_id.upper()):
             genes_by_go[go_id] |= genes_by_go[go_child]
 
     # Reset defaultdict to dict
@@ -447,7 +449,7 @@ def build_networks(
         }
 
         if not prop_dict:
-            # logger.info(f"No statements for ID {go_id}")
+            tqdm.write(f"No statements for ID {go_id}")
             skipped += 1
             continue
 

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -20,6 +20,7 @@ from neo4j.exceptions import CypherSyntaxError
 from requests import ReadTimeout
 from indra.ontology.bio import bio_ontology
 from indra_cogex.client.neo4j_client import Neo4jClient
+# Todo: use the CurationCache from CoGEx?
 from indra_db.client.principal.curation import get_curations
 from ndex2 import NiceCXNetwork, create_nice_cx_from_server
 from tqdm import tqdm
@@ -922,6 +923,121 @@ def delete_networks(network_uuids: Set[str], ndex_client: ndex2.Ndex2):
         logger.warning(f"{len(failed)} deletions failed")
 
     return failed
+
+
+def make_network_writable(
+    uuid: str,
+    ndex_client: Optional[ndex2.Ndex2] = None,
+    attempts: int = 3
+) -> bool:
+    """Change the network properties to make it writable.
+
+    Parameters
+    ----------
+    uuid :
+        The UUID of the network to make writable.
+    ndex_client :
+        The ndex client to use for making the network writable. If None, a new
+        client will be created using `get_ndex_web_client()` for this call only.
+    attempts :
+        The number of attempts to retry making the network writable in case of
+        network issues. Default is 3.
+
+    Returns
+    -------
+
+    """
+    if ndex_client is None:
+        ndex_client = get_ndex_web_client()
+
+    for attempt in range(attempts):
+        try:
+            res = ndex_client.set_network_system_properties(
+                network_id=uuid,
+                network_properties={
+                    # Make the network writable
+                    "readOnly": False
+                }
+            )
+            success = True
+            return success
+        except Exception as e:
+            if attempt < attempts - 1:
+                # Retry on failure
+                tqdm.write(
+                    f"Attempt {attempt + 1} to make network {uuid} writable failed: {e}. "
+                    f"Retrying..."
+                )
+                sleep(1)
+            else:
+                # Failed after all attempts
+                tqdm.write(
+                    f"Failed to make network {uuid} writable after {attempts} attempts: {e}. "
+                    f"Please check the network manually."
+                )
+                return False
+
+    # We should not reach this point, but print a message just in case
+    tqdm.write(f"WARNING: Ended loop in make_network_writable for uuid {uuid}. "
+               f"This should not happen, please check the logic.")
+    return False
+
+
+def make_network_readonly(
+    uuid: str,
+    ndex_client: Optional[ndex2.Ndex2] = None,
+    attempts: int = 3
+) -> bool:
+    """Change the network properties to make it writable.
+
+    Parameters
+    ----------
+    uuid :
+        The UUID of the network to make writable.
+    ndex_client :
+        The ndex client to use for making the network writable. If None, a new
+        client will be created using `get_ndex_web_client()` for this call only.
+    attempts :
+        The number of attempts to retry making the network writable in case of
+        network issues. Default is 3.
+
+    Returns
+    -------
+
+    """
+    if ndex_client is None:
+        ndex_client = get_ndex_web_client()
+
+    for attempt in range(attempts):
+        try:
+            res = ndex_client.set_network_system_properties(
+                network_id=uuid,
+                network_properties={
+                    # Make the network writable
+                    "readOnly": True
+                }
+            )
+            return True
+        except Exception as e:
+            if attempt < attempts - 1:
+                # Retry on failure
+                tqdm.write(
+                    f"Attempt {attempt + 1} to make network {uuid} writable failed: {e}. "
+                    f"Retrying..."
+                )
+                sleep(1)
+            else:
+                # Failed after all attempts
+                tqdm.write(
+                    f"Failed to make network {uuid} writable after {attempts} attempts: {e}. "
+                    f"Please check the network manually."
+                )
+                return False
+
+    # We should not reach this point, but print a message just in case
+    tqdm.write(f"WARNING: Ended loop in make_network_writable for uuid {uuid}. "
+               f"This should not happen, please check the logic.")
+    return False
 
 
 def make_network_public_and_visible(

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -924,6 +924,67 @@ def delete_networks(network_uuids: Set[str], ndex_client: ndex2.Ndex2):
     return failed
 
 
+def make_network_public_and_visible(
+    uuid: str,
+    ndex_client: Optional[ndex2.Ndex2] = None,
+    attempts: int = 3
+) -> bool:
+    """Make a network public and visible on NDEx.
+
+    Parameters
+    ----------
+    uuid :
+        The UUID of the network to make public.
+    ndex_client :
+        An optional NDEx client. If None, a new client will be created.
+    attempts :
+        The number of time to retry making the network public in case of network
+        issues. Default is 3.
+
+    Returns
+    -------
+    :
+        True if the request was successfully processed.
+    """
+    if ndex_client is None:
+        ndex_client = get_ndex_web_client()
+
+    for attempt in range(attempts):
+        try:
+            res = ndex_client.set_network_system_properties(
+                network_id=uuid,
+                network_properties={
+                    # Showcase: network will display on the home page for other users
+                    "showcase": True,
+                    # PUBLIC: Network can be found or read by anyone
+                    "visibility": "PUBLIC",
+                    # "Full index on the network" (unclear, but was recommended by
+                    # the ndex group)
+                    "index_level": "ALL",
+                    # Readonly access makes any attempt to edit the network fail,
+                    # Has to be set to False before delete or update.
+                    "readOnly": True
+                }
+            )
+            return True
+        except Exception as e:
+            if attempt < attempts - 1:
+                # Retry on failure
+                tqdm.write(
+                    f"Attempt {attempt + 1} to make network {uuid} public failed: {e}. "
+                    f"Retrying..."
+                )
+                sleep(1)
+            else:
+                tqdm.write(
+                    f"Failed to make network {uuid} public after {attempts} attempts: {e}. "
+                    f"Please check the network manually."
+                )
+                return False
+
+    return True
+
+
 def format_and_update_network(
     ncx: NiceCXNetwork,
     network_set_id: str,

--- a/go_networks/generate_v2.py
+++ b/go_networks/generate_v2.py
@@ -5,7 +5,7 @@ import json
 import logging
 import pickle
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, UTC
 from itertools import combinations
 from textwrap import dedent
 from typing import Dict, Iterator, Optional, Set, Tuple, Union, List
@@ -53,6 +53,10 @@ MAX_GENE_COUNT = 200
 DB_SOURCES = ["biogrid", "hprd", "signor", "phosphoelm", "signor", "biopax"]
 
 logger = logging.getLogger(__name__)
+
+
+def _get_utc_now(fmt: str = "%Y-%m-%d_%H-%M-%S") -> str:
+    return datetime.now(UTC).strftime(fmt)
 
 
 def get_curation_set() -> Set[int]:
@@ -432,9 +436,17 @@ def build_networks(
         Dict of assembled networks by go id
     """
     networks = {}
-    skipped = 0
+    skipped = []
+
     # Only pass the relevant parts of the pair_props dict
-    for go_id, gene_set in tqdm(go2genes_map.items(), total=len(go2genes_map)):
+    if not bio_ontology._initialized:
+        logger.info("Warming up bio_ontology...")
+        bio_ontology.initialize()
+    for go_id, gene_set in tqdm(
+        go2genes_map.items(),
+        total=len(go2genes_map),
+        desc="Assembling networks from props"
+    ):
         if TEST_GO_ID and go_id != TEST_GO_ID:
             continue
 
@@ -449,8 +461,7 @@ def build_networks(
         }
 
         if not prop_dict:
-            tqdm.write(f"No statements for ID {go_id}")
-            skipped += 1
+            skipped.append(go_id)
             continue
 
         gna = GoNetworkAssembler(
@@ -465,7 +476,13 @@ def build_networks(
             "min_score": min(gna.rel_scores),
         }
 
-    logger.info(f"Skipped {skipped} networks without statements")
+    logger.info(f"Skipped {len(skipped)} networks without statements")
+    if skipped:
+        utc_str = _get_utc_now()
+        fname = f"{utc_str}_skipped_go_ids.txt"
+        logger.info(f"Writing skipped GO IDs to file: {fname}")
+        with cache.join(name=fname).open("w") as f:
+            f.write('\n'.join(skipped))
     return networks
 
 


### PR DESCRIPTION
This PR contains all the changes that were done for the latest round of updated to CoGEx supported GO networks uploaded to ndex.org

Specific changes: 
- Fall back on a non-APOC query when APOC is not installed on the DB
- Implement retry logic for various API calls to handle unstable connections
- Switch to child -> parent logic when making the GO-gene set lookup
- Update how to make networks public
